### PR TITLE
parse RssItem.pubDate to DateTime

### DIFF
--- a/lib/domain/rss_item.dart
+++ b/lib/domain/rss_item.dart
@@ -1,3 +1,4 @@
+import 'package:intl/intl.dart';
 import 'package:webfeed/domain/dublin_core/dublin_core.dart';
 import 'package:webfeed/domain/media/media.dart';
 import 'package:webfeed/domain/rss_category.dart';
@@ -16,7 +17,7 @@ class RssItem {
 
   final List<RssCategory> categories;
   final String guid;
-  final String pubDate;
+  final DateTime pubDate;
   final String author;
   final String comments;
   final RssSource source;
@@ -32,7 +33,7 @@ class RssItem {
     this.link,
     this.categories,
     this.guid,
-    this.pubDate,
+    String pubDate,
     this.author,
     this.comments,
     this.source,
@@ -41,7 +42,8 @@ class RssItem {
     this.enclosure,
     this.dc,
     this.itunes,
-  });
+  })
+    : this.pubDate = _parsePubDate(pubDate);
 
   factory RssItem.parse(XmlElement element) {
     return RssItem(
@@ -62,5 +64,11 @@ class RssItem {
       dc: DublinCore.parse(element),
       itunes: RssItemItunes.parse(element),
     );
+  }
+
+  static _parsePubDate(pubDate) {
+    if (pubDate == null) return null;
+    //Locale for pubDate is always en_US, regardless of device locale
+    return DateFormat('EEE, dd MMM yyyy HH:mm:ss Z', 'en_US').parse(pubDate);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 dependencies:
   xml: "^3.0.0"
+  intl: "^0.16.0"
 dev_dependencies:
   test: ^1.3.0
   http: "^0.11.3+16"

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -72,7 +72,7 @@ void main() {
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit");
     expect(feed.items.first.link, "https://foo.bar.news/1");
     expect(feed.items.first.guid, "https://foo.bar.news/1?guid");
-    expect(feed.items.first.pubDate, "Mon, 26 Mar 2018 14:00:00 PDT");
+    expect(feed.items.first.pubDate, DateTime(2018, 03, 26, 14)); //Mon, 26 Mar 2018 14:00:00 PDT
     expect(feed.items.first.categories.first.domain, "news");
     expect(feed.items.first.categories.first.value, "Lorem");
     expect(feed.items.first.author, "alice@foo.bar.news");
@@ -102,7 +102,7 @@ void main() {
     var item = feed.items.first;
     expect(item.title, null);
     expect(item.link, "http://www.foo.com");
-    expect(item.pubDate, "Mon, 27 Aug 2001 16:08:56 PST");
+    expect(item.pubDate, DateTime(2001, 08, 27, 16, 08, 56)); //Mon, 27 Aug 2001 16:08:56 PST
 
     expect(item.media.group.contents.length, 5);
     expect(item.media.group.credits.length, 2);


### PR DESCRIPTION
Hi, hope you're open to pull requests?

This changes the type of `RssItem.pubDate` from `String` to `DateTime`, saving end developers from having to learn how RSS dates are stored and write their own parser.

It should be particularly helpful as `pubDate` [conforms to RFC 822](https://validator.w3.org/feed/docs/error/InvalidRFC2822Date.html) instead of ISO 8601, meaning you can't simply use `DateTime.parse()`.

This will be a breaking API change, I've updated  the relevant tests to validate against `DateTime` objects instead of strings.