### PR TITLE
Make seconds optional in pubDate (RFC-822)

### DIFF
--- a/lib/util/datetime.dart
+++ b/lib/util/datetime.dart
@@ -1,6 +1,8 @@
 import 'package:intl/intl.dart';
 
 const rfc822DatePattern = 'EEE, dd MMM yyyy HH:mm:ss Z';
+const rfc822DateWithoutSecondsPattern = 'EEE, dd MMM yyyy HH:mm Z';
+const rfc822DateOnlyPattern = 'EEE, dd MMM yyyy';
 
 DateTime parseDateTime(dateString) {
   if (dateString == null) return null;
@@ -9,9 +11,14 @@ DateTime parseDateTime(dateString) {
 
 DateTime _parseRfc822DateTime(String dateString) {
   try {
-    final length = dateString?.length?.clamp(0, rfc822DatePattern.length);
-    final trimmedPattern = rfc822DatePattern.substring(0, length); //Some feeds use a shortened RFC 822 date, e.g. 'Tue, 04 Aug 2020'
-    final format = DateFormat(trimmedPattern, 'en_US');
+    var pattern = rfc822DateOnlyPattern;
+    if (dateString.contains(RegExp(r'(0?[1-9]|1[0-2]):[0-5][0-9]:[0-5][0-9]'))) {
+      pattern = rfc822DatePattern;
+    } else if (dateString.contains(RegExp(r'(0?[1-9]|1[0-2]):[0-5][0-9]'))) {
+      pattern = rfc822DateWithoutSecondsPattern;
+    }
+
+    final format = DateFormat(pattern, 'en_US');
     return format.parse(dateString);
   } on FormatException {
     return null;

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -64,7 +64,7 @@ void main() {
     expect(feed.skipHours.contains(3), true);
     expect(feed.skipHours.contains(4), true);
 
-    expect(feed.items.length, 2);
+    expect(feed.items.length, 3);
 
     expect(feed.items.first.title,
         'The standard Lorem Ipsum passage, used since the 1500s');
@@ -73,7 +73,7 @@ void main() {
     expect(feed.items.first.link, 'https://foo.bar.news/1');
     expect(feed.items.first.guid, 'https://foo.bar.news/1?guid');
     expect(feed.items.first.pubDate,
-        DateTime(2018, 03, 26, 14)); //Mon, 26 Mar 2018 14:00:00 PDT
+        DateTime(2018, 03, 26, 14)); // Mon, 26 Mar 2018 14:00:00 PDT
     expect(feed.items.first.categories.first.domain, 'news');
     expect(feed.items.first.categories.first.value, 'Lorem');
     expect(feed.items.first.author, 'alice@foo.bar.news');
@@ -89,6 +89,12 @@ void main() {
         '<img width="1000" height="690" src="https://test.com/image_link"/> Test content<br />');
     expect(
         feed.items.first.content.images.first, 'https://test.com/image_link');
+
+    // DateTime without seconds, Tue, 20 Mar 2018 10:00 PDT
+    expect(feed.items[1].pubDate, DateTime(2018, 03, 20, 10));
+
+    // Date only, Tue, 20 Mar 2018
+    expect(feed.items[2].pubDate, DateTime(2018, 03, 20));
   });
   test('parse RSS-Media.xml', () {
     var xmlString = File('test/xml/RSS-Media.xml').readAsStringSync();

--- a/test/xml/RSS.xml
+++ b/test/xml/RSS.xml
@@ -58,10 +58,22 @@
                 laudantium
             </description>
             <category domain="auto">Ipsum</category>
-            <pubDate>Tue, 20 Mar 2018 10:00:00 PDT</pubDate>
+            <pubDate>Tue, 20 Mar 2018 10:00 PDT</pubDate>
             <author>bob@foo.bar.news</author>
             <source url="https://foo.bar.news/2?source">Lorem Ipsum</source>
             <comments>https://foo.bar.news/2/comments</comments>
+        </item>
+        <item>
+            <title>Lorem ipsum dolor sit amet, consetetur</title>
+            <link>https://foo.bar.news/3</link>
+            <guid>https://foo.bar.news/3?guid</guid>
+            <description>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+            </description>
+            <category domain="auto">Ipsum</category>
+            <pubDate>Tue, 20 Mar 2018</pubDate>
+            <author>bob@foo.bar.news</author>
+            <source url="https://foo.bar.news/3?source">Lorem Ipsum</source>
+            <comments>https://foo.bar.news/3/comments</comments>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Using this with the https://www.nasa.gov/rss/dyn/lg_image_of_the_day.rss, always let to `pubDate` being null.

Adjusted the RFC-822 DateTime implementation to accept time without seconds. This seems to be according to its definition: https://www.w3.org/Protocols/rfc822/#z28

Also amended tests to cover this as well as https://github.com/witochandra/webfeed/pull/34 :wink: 