### PR TITLE
Migration to null safety dart 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ doc/api/
 
 .idea
 .dart_tool
+
+.vscode/

--- a/example/main.dart
+++ b/example/main.dart
@@ -5,13 +5,14 @@ void main() async {
   var client = http.Client();
 
   // RSS feed
-  var response = await client
-      .get('https://developer.apple.com/news/releases/rss/releases.rss');
+  var response = await client.get(
+      Uri(path: 'https://developer.apple.com/news/releases/rss/releases.rss'));
   var channel = RssFeed.parse(response.body);
   print(channel);
 
   // Atom feed
-  response = await client.get('https://www.theverge.com/rss/index.xml');
+  response =
+      await client.get(Uri(path: 'https://www.theverge.com/rss/index.xml'));
   var feed = AtomFeed.parse(response.body);
   print(feed);
 

--- a/lib/domain/atom_category.dart
+++ b/lib/domain/atom_category.dart
@@ -1,9 +1,9 @@
 import 'package:xml/xml.dart';
 
 class AtomCategory {
-  final String term;
-  final String scheme;
-  final String label;
+  final String? term;
+  final String? scheme;
+  final String? label;
 
   AtomCategory(this.term, this.scheme, this.label);
 

--- a/lib/domain/atom_feed.dart
+++ b/lib/domain/atom_feed.dart
@@ -8,20 +8,20 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class AtomFeed {
-  final String id;
-  final String title;
-  final DateTime updated;
-  final List<AtomItem> items;
+  final String? id;
+  final String? title;
+  final DateTime? updated;
+  final List<AtomItem>? items;
 
-  final List<AtomLink> links;
-  final List<AtomPerson> authors;
-  final List<AtomPerson> contributors;
-  final List<AtomCategory> categories;
-  final AtomGenerator generator;
-  final String icon;
-  final String logo;
-  final String rights;
-  final String subtitle;
+  final List<AtomLink>? links;
+  final List<AtomPerson>? authors;
+  final List<AtomPerson>? contributors;
+  final List<AtomCategory>? categories;
+  final AtomGenerator? generator;
+  final String? icon;
+  final String? logo;
+  final String? rights;
+  final String? subtitle;
 
   AtomFeed({
     this.id,

--- a/lib/domain/atom_generator.dart
+++ b/lib/domain/atom_generator.dart
@@ -1,16 +1,14 @@
 import 'package:xml/xml.dart';
 
 class AtomGenerator {
-  final String uri;
-  final String version;
-  final String value;
+  final String? uri;
+  final String? version;
+  final String? value;
 
   AtomGenerator(this.uri, this.version, this.value);
 
-  factory AtomGenerator.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     var uri = element.getAttribute('uri');
     var version = element.getAttribute('version');
     var value = element.text;

--- a/lib/domain/atom_item.dart
+++ b/lib/domain/atom_item.dart
@@ -8,20 +8,20 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class AtomItem {
-  final String id;
-  final String title;
-  final DateTime updated;
+  final String? id;
+  final String? title;
+  final DateTime? updated;
 
-  final List<AtomPerson> authors;
-  final List<AtomLink> links;
-  final List<AtomCategory> categories;
-  final List<AtomPerson> contributors;
-  final AtomSource source;
-  final String published;
-  final String content;
-  final String summary;
-  final String rights;
-  final Media media;
+  final List<AtomPerson>? authors;
+  final List<AtomLink>? links;
+  final List<AtomCategory>? categories;
+  final List<AtomPerson>? contributors;
+  final AtomSource? source;
+  final String? published;
+  final String? content;
+  final String? summary;
+  final String? rights;
+  final Media? media;
 
   AtomItem({
     this.id,

--- a/lib/domain/atom_link.dart
+++ b/lib/domain/atom_link.dart
@@ -1,11 +1,11 @@
 import 'package:xml/xml.dart';
 
 class AtomLink {
-  final String href;
-  final String rel;
-  final String type;
-  final String hreflang;
-  final String title;
+  final String? href;
+  final String? rel;
+  final String? type;
+  final String? hreflang;
+  final String? title;
   final int length;
 
   AtomLink(
@@ -25,7 +25,7 @@ class AtomLink {
     var hreflang = element.getAttribute('hreflang');
     var length = 0;
     if (element.getAttribute('length') != null) {
-      length = int.parse(element.getAttribute('length'));
+      length = int.parse(element.getAttribute('length')!);
     }
     return AtomLink(href, rel, type, hreflang, title, length);
   }

--- a/lib/domain/atom_person.dart
+++ b/lib/domain/atom_person.dart
@@ -2,9 +2,9 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class AtomPerson {
-  final String name;
-  final String uri;
-  final String email;
+  final String? name;
+  final String? uri;
+  final String? email;
 
   AtomPerson({this.name, this.uri, this.email});
 

--- a/lib/domain/atom_source.dart
+++ b/lib/domain/atom_source.dart
@@ -2,9 +2,9 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class AtomSource {
-  final String id;
-  final String title;
-  final String updated;
+  final String? id;
+  final String? title;
+  final String? updated;
 
   AtomSource({
     this.id,
@@ -12,10 +12,8 @@ class AtomSource {
     this.updated,
   });
 
-  factory AtomSource.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return AtomSource(
       id: findFirstElement(element, 'id')?.text,
       title: findFirstElement(element, 'title')?.text,

--- a/lib/domain/dublin_core/dublin_core.dart
+++ b/lib/domain/dublin_core/dublin_core.dart
@@ -3,23 +3,23 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class DublinCore {
-  final String title;
-  final String description;
-  final String creator;
-  final String subject;
-  final String publisher;
-  final String contributor;
-  final DateTime date;
-  final DateTime created;
-  final DateTime modified;
-  final String type;
-  final String format;
-  final String identifier;
-  final String source;
-  final String language;
-  final String relation;
-  final String coverage;
-  final String rights;
+  final String? title;
+  final String? description;
+  final String? creator;
+  final String? subject;
+  final String? publisher;
+  final String? contributor;
+  final DateTime? date;
+  final DateTime? created;
+  final DateTime? modified;
+  final String? type;
+  final String? format;
+  final String? identifier;
+  final String? source;
+  final String? language;
+  final String? relation;
+  final String? coverage;
+  final String? rights;
 
   DublinCore({
     this.title,
@@ -41,7 +41,7 @@ class DublinCore {
     this.rights,
   });
 
-  factory DublinCore.parse(XmlElement element) {
+  static parse(XmlElement? element) {
     if (element == null) {
       return null;
     }

--- a/lib/domain/itunes/itunes.dart
+++ b/lib/domain/itunes/itunes.dart
@@ -7,23 +7,23 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class Itunes {
-  final String author;
-  final String summary;
-  final bool explicit;
-  final String title;
-  final String subtitle;
-  final ItunesOwner owner;
-  final List<String> keywords;
-  final ItunesImage image;
-  final List<ItunesCategory> categories;
-  final ItunesType type;
-  final String newFeedUrl;
-  final bool block;
-  final bool complete;
-  final int episode;
-  final int season;
-  final Duration duration;
-  final ItunesEpisodeType episodeType;
+  final String? author;
+  final String? summary;
+  final bool? explicit;
+  final String? title;
+  final String? subtitle;
+  final ItunesOwner? owner;
+  final List<String>? keywords;
+  final ItunesImage? image;
+  final List<ItunesCategory?>? categories;
+  final ItunesType? type;
+  final String? newFeedUrl;
+  final bool? block;
+  final bool? complete;
+  final int? episode;
+  final int? season;
+  final Duration? duration;
+  final ItunesEpisodeType? episodeType;
 
   Itunes({
     this.author,
@@ -45,7 +45,7 @@ class Itunes {
     this.episodeType,
   });
 
-  factory Itunes.parse(XmlElement element) {
+  static parse(XmlElement? element) {
     if (element == null) {
       return null;
     }
@@ -61,12 +61,12 @@ class Itunes {
       owner: ItunesOwner.parse(findFirstElement(element, 'itunes:owner')),
       keywords: findFirstElement(element, 'itunes:keywords')
               ?.text
-              ?.split(',')
-              ?.map((keyword) => keyword.trim())
-              ?.toList() ??
+              .split(',')
+              .map((keyword) => keyword.trim())
+              .toList() ??
           [],
       image: ItunesImage.parse(findFirstElement(element, 'itunes:image')),
-      categories: findElements(element, 'itunes:category')
+      categories: findElements(element, 'itunes:category')!
           .map((e) => ItunesCategory.parse(e))
           .toList(),
       type: newItunesType(findFirstElement(element, 'itunes:type')),

--- a/lib/domain/itunes/itunes_category.dart
+++ b/lib/domain/itunes/itunes_category.dart
@@ -1,20 +1,18 @@
 import 'package:xml/xml.dart';
 
 class ItunesCategory {
-  final String category;
-  final List<String> subCategories;
+  final String? category;
+  final List<String?>? subCategories;
 
   ItunesCategory({this.category, this.subCategories});
 
-  factory ItunesCategory.parse(XmlElement element) {
+  static ItunesCategory? parse(XmlElement? element) {
     if (element == null) return null;
     return ItunesCategory(
-      category: element.getAttribute('text')?.trim(),
-      subCategories: element
-              .findElements('itunes:category')
-              ?.map((e) => e.getAttribute('text')?.trim())
-              ?.toList() ??
-          [],
-    );
+        category: element.getAttribute('text')?.trim(),
+        subCategories: element
+            .findElements('itunes:category')
+            .map((e) => e.getAttribute('text')?.trim())
+            .toList());
   }
 }

--- a/lib/domain/itunes/itunes_episode_type.dart
+++ b/lib/domain/itunes/itunes_episode_type.dart
@@ -2,7 +2,7 @@ import 'package:xml/xml.dart';
 
 enum ItunesEpisodeType { full, trailer, bonus, unknown }
 
-ItunesEpisodeType newItunesEpisodeType(XmlElement element) {
+ItunesEpisodeType newItunesEpisodeType(XmlElement? element) {
   switch (element?.text) {
     case 'full':
       return ItunesEpisodeType.full;

--- a/lib/domain/itunes/itunes_image.dart
+++ b/lib/domain/itunes/itunes_image.dart
@@ -1,14 +1,17 @@
 import 'package:xml/xml.dart';
 
 class ItunesImage {
-  final String href;
+  final String? href;
 
   ItunesImage({this.href});
 
-  factory ItunesImage.parse(XmlElement element) {
+  static parse(XmlElement? element) {
+    ItunesImage? result;
     if (element == null) return null;
-    return ItunesImage(
+    result = ItunesImage(
       href: element.getAttribute('href')?.trim(),
     );
+
+    return result;
   }
 }

--- a/lib/domain/itunes/itunes_owner.dart
+++ b/lib/domain/itunes/itunes_owner.dart
@@ -2,16 +2,15 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class ItunesOwner {
-  final String name;
-  final String email;
+  final String? name;
+  final String? email;
 
   ItunesOwner({this.name, this.email});
 
-  factory ItunesOwner.parse(XmlElement element) {
-    if (element == null) return null;
+  factory ItunesOwner.parse(XmlElement? element) {
     return ItunesOwner(
-      name: findFirstElement(element, 'itunes:name')?.text?.trim(),
-      email: findFirstElement(element, 'itunes:email')?.text?.trim(),
+      name: findFirstElement(element, 'itunes:name')?.text.trim(),
+      email: findFirstElement(element, 'itunes:email')?.text.trim(),
     );
   }
 }

--- a/lib/domain/itunes/itunes_type.dart
+++ b/lib/domain/itunes/itunes_type.dart
@@ -2,7 +2,7 @@ import 'package:xml/xml.dart';
 
 enum ItunesType { episodic, serial, unknown }
 
-ItunesType newItunesType(XmlElement element) {
+ItunesType newItunesType(XmlElement? element) {
   switch (element?.text) {
     case 'episodic':
       return ItunesType.episodic;

--- a/lib/domain/media/category.dart
+++ b/lib/domain/media/category.dart
@@ -1,9 +1,9 @@
 import 'package:xml/xml.dart';
 
 class Category {
-  final String scheme;
-  final String label;
-  final String value;
+  final String? scheme;
+  final String? label;
+  final String? value;
 
   Category({
     this.scheme,
@@ -11,10 +11,8 @@ class Category {
     this.value,
   });
 
-  factory Category.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Category(
       scheme: element.getAttribute('scheme'),
       label: element.getAttribute('label'),

--- a/lib/domain/media/community.dart
+++ b/lib/domain/media/community.dart
@@ -5,9 +5,9 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class Community {
-  final StarRating starRating;
-  final Statistics statistics;
-  final Tags tags;
+  final StarRating? starRating;
+  final Statistics? statistics;
+  final Tags? tags;
 
   Community({
     this.starRating,
@@ -15,10 +15,8 @@ class Community {
     this.tags,
   });
 
-  factory Community.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Community(
       starRating: StarRating.parse(
         findFirstElement(element, 'media:starRating'),

--- a/lib/domain/media/content.dart
+++ b/lib/domain/media/content.dart
@@ -1,20 +1,20 @@
 import 'package:xml/xml.dart';
 
 class Content {
-  final String url;
-  final String type;
-  final int fileSize;
-  final String medium;
-  final bool isDefault;
-  final String expression;
-  final int bitrate;
-  final double framerate;
-  final double samplingrate;
-  final int channels;
-  final int duration;
-  final int height;
-  final int width;
-  final String lang;
+  final String? url;
+  final String? type;
+  final int? fileSize;
+  final String? medium;
+  final bool? isDefault;
+  final String? expression;
+  final int? bitrate;
+  final double? framerate;
+  final double? samplingrate;
+  final int? channels;
+  final int? duration;
+  final int? height;
+  final int? width;
+  final String? lang;
 
   Content({
     this.url,

--- a/lib/domain/media/copyright.dart
+++ b/lib/domain/media/copyright.dart
@@ -1,18 +1,16 @@
 import 'package:xml/xml.dart';
 
 class Copyright {
-  final String url;
-  final String value;
+  final String? url;
+  final String? value;
 
   Copyright({
     this.url,
     this.value,
   });
 
-  factory Copyright.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Copyright(
       url: element.getAttribute('url'),
       value: element.text,

--- a/lib/domain/media/credit.dart
+++ b/lib/domain/media/credit.dart
@@ -1,9 +1,9 @@
 import 'package:xml/xml.dart';
 
 class Credit {
-  final String role;
-  final String scheme;
-  final String value;
+  final String? role;
+  final String? scheme;
+  final String? value;
 
   Credit({
     this.role,

--- a/lib/domain/media/description.dart
+++ b/lib/domain/media/description.dart
@@ -1,18 +1,16 @@
 import 'package:xml/xml.dart';
 
 class Description {
-  final String type;
-  final String value;
+  final String? type;
+  final String? value;
 
   Description({
     this.type,
     this.value,
   });
 
-  factory Description.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Description(
       type: element.getAttribute('type'),
       value: element.text,

--- a/lib/domain/media/embed.dart
+++ b/lib/domain/media/embed.dart
@@ -2,10 +2,10 @@ import 'package:webfeed/domain/media/param.dart';
 import 'package:xml/xml.dart';
 
 class Embed {
-  final String url;
-  final int width;
-  final int height;
-  final List<Param> params;
+  final String? url;
+  final int? width;
+  final int? height;
+  final List<Param?>? params;
 
   Embed({
     this.url,
@@ -14,10 +14,8 @@ class Embed {
     this.params,
   });
 
-  factory Embed.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Embed(
       url: element.getAttribute('url'),
       width: int.tryParse(element.getAttribute('width') ?? '0'),

--- a/lib/domain/media/group.dart
+++ b/lib/domain/media/group.dart
@@ -6,10 +6,10 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class Group {
-  final List<Content> contents;
-  final List<Credit> credits;
-  final Category category;
-  final Rating rating;
+  final List<Content>? contents;
+  final List<Credit>? credits;
+  final Category? category;
+  final Rating? rating;
 
   Group({
     this.contents,
@@ -18,10 +18,8 @@ class Group {
     this.rating,
   });
 
-  factory Group.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Group(
       contents: element.findElements('media:content').map((e) {
         return Content.parse(e);

--- a/lib/domain/media/hash.dart
+++ b/lib/domain/media/hash.dart
@@ -1,18 +1,16 @@
 import 'package:xml/xml.dart';
 
 class Hash {
-  final String algo;
-  final String value;
+  final String? algo;
+  final String? value;
 
   Hash({
     this.algo,
     this.value,
   });
 
-  factory Hash.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Hash(
       algo: element.getAttribute('algo'),
       value: element.text,

--- a/lib/domain/media/license.dart
+++ b/lib/domain/media/license.dart
@@ -1,9 +1,9 @@
 import 'package:xml/xml.dart';
 
 class License {
-  final String type;
-  final String href;
-  final String value;
+  final String? type;
+  final String? href;
+  final String? value;
 
   License({
     this.type,
@@ -11,10 +11,8 @@ class License {
     this.value,
   });
 
-  factory License.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return License(
       type: element.getAttribute('type'),
       href: element.getAttribute('href'),

--- a/lib/domain/media/media.dart
+++ b/lib/domain/media/media.dart
@@ -23,31 +23,31 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class Media {
-  final Group group;
-  final List<Content> contents;
-  final List<Credit> credits;
-  final Category category;
-  final Rating rating;
-  final Title title;
-  final Description description;
-  final String keywords;
-  final List<Thumbnail> thumbnails;
-  final Hash hash;
-  final Player player;
-  final Copyright copyright;
-  final Text text;
-  final Restriction restriction;
-  final Community community;
-  final List<String> comments;
-  final Embed embed;
-  final List<String> responses;
-  final List<String> backLinks;
-  final Status status;
-  final List<Price> prices;
-  final License license;
-  final PeerLink peerLink;
-  final Rights rights;
-  final List<Scene> scenes;
+  final Group? group;
+  final List<Content>? contents;
+  final List<Credit>? credits;
+  final Category? category;
+  final Rating? rating;
+  final Title? title;
+  final Description? description;
+  final String? keywords;
+  final List<Thumbnail>? thumbnails;
+  final Hash? hash;
+  final Player? player;
+  final Copyright? copyright;
+  final Text? text;
+  final Restriction? restriction;
+  final Community? community;
+  final List<String>? comments;
+  final Embed? embed;
+  final List<String>? responses;
+  final List<String>? backLinks;
+  final Status? status;
+  final List<Price>? prices;
+  final License? license;
+  final PeerLink? peerLink;
+  final Rights? rights;
+  final List<Scene?>? scenes;
 
   Media({
     this.group,
@@ -124,24 +124,24 @@ class Media {
       ),
       comments: findFirstElement(element, 'media:comments')
               ?.findElements('media:comment')
-              ?.map((e) {
+              .map((e) {
             return e.text;
-          })?.toList() ??
+          }).toList() ??
           [],
       embed: Embed.parse(
         findFirstElement(element, 'media:embed'),
       ),
       responses: findFirstElement(element, 'media:responses')
               ?.findElements('media:response')
-              ?.map((e) {
+              .map((e) {
             return e.text;
-          })?.toList() ??
+          }).toList() ??
           [],
       backLinks: findFirstElement(element, 'media:backLinks')
               ?.findElements('media:backLink')
-              ?.map((e) {
+              .map((e) {
             return e.text;
-          })?.toList() ??
+          }).toList() ??
           [],
       status: Status.parse(
         findFirstElement(element, 'media:status'),
@@ -160,9 +160,9 @@ class Media {
       ),
       scenes: findFirstElement(element, 'media:scenes')
               ?.findElements('media:scene')
-              ?.map((e) {
+              .map((e) {
             return Scene.parse(e);
-          })?.toList() ??
+          }).toList() ??
           [],
     );
   }

--- a/lib/domain/media/param.dart
+++ b/lib/domain/media/param.dart
@@ -1,18 +1,16 @@
 import 'package:xml/xml.dart';
 
 class Param {
-  final String name;
-  final String value;
+  final String? name;
+  final String? value;
 
   Param({
     this.name,
     this.value,
   });
 
-  factory Param.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static Param? parse(XmlElement? element) {
+    if (element == null) return null;
     return Param(
       name: element.getAttribute('name'),
       value: element.text,

--- a/lib/domain/media/peer_link.dart
+++ b/lib/domain/media/peer_link.dart
@@ -1,9 +1,9 @@
 import 'package:xml/xml.dart';
 
 class PeerLink {
-  final String type;
-  final String href;
-  final String value;
+  final String? type;
+  final String? href;
+  final String? value;
 
   PeerLink({
     this.type,
@@ -11,10 +11,8 @@ class PeerLink {
     this.value,
   });
 
-  factory PeerLink.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return PeerLink(
       type: element.getAttribute('type'),
       href: element.getAttribute('href'),

--- a/lib/domain/media/player.dart
+++ b/lib/domain/media/player.dart
@@ -1,10 +1,10 @@
 import 'package:xml/xml.dart';
 
 class Player {
-  final String url;
-  final int width;
-  final int height;
-  final String value;
+  final String? url;
+  final int? width;
+  final int? height;
+  final String? value;
 
   Player({
     this.url,
@@ -13,10 +13,8 @@ class Player {
     this.value,
   });
 
-  factory Player.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Player(
       url: element.getAttribute('url'),
       width: int.tryParse(element.getAttribute('width') ?? '0'),

--- a/lib/domain/media/price.dart
+++ b/lib/domain/media/price.dart
@@ -1,10 +1,10 @@
 import 'package:xml/xml.dart';
 
 class Price {
-  final double price;
-  final String type;
-  final String info;
-  final String currency;
+  final double? price;
+  final String? type;
+  final String? info;
+  final String? currency;
 
   Price({
     this.price,

--- a/lib/domain/media/rating.dart
+++ b/lib/domain/media/rating.dart
@@ -1,18 +1,16 @@
 import 'package:xml/xml.dart';
 
 class Rating {
-  final String scheme;
-  final String value;
+  final String? scheme;
+  final String? value;
 
   Rating({
     this.scheme,
     this.value,
   });
 
-  factory Rating.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Rating(
       scheme: element.getAttribute('scheme'),
       value: element.text,

--- a/lib/domain/media/restriction.dart
+++ b/lib/domain/media/restriction.dart
@@ -1,9 +1,9 @@
 import 'package:xml/xml.dart';
 
 class Restriction {
-  final String relationship;
-  final String type;
-  final String value;
+  final String? relationship;
+  final String? type;
+  final String? value;
 
   Restriction({
     this.relationship,
@@ -11,10 +11,8 @@ class Restriction {
     this.value,
   });
 
-  factory Restriction.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Restriction(
       relationship: element.getAttribute('relationship'),
       type: element.getAttribute('type'),

--- a/lib/domain/media/rights.dart
+++ b/lib/domain/media/rights.dart
@@ -1,16 +1,14 @@
 import 'package:xml/xml.dart';
 
 class Rights {
-  final String status;
+  final String? status;
 
   Rights({
     this.status,
   });
 
-  factory Rights.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Rights(
       status: element.getAttribute('status'),
     );

--- a/lib/domain/media/scene.dart
+++ b/lib/domain/media/scene.dart
@@ -2,10 +2,10 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class Scene {
-  final String title;
-  final String description;
-  final String startTime;
-  final String endTime;
+  final String? title;
+  final String? description;
+  final String? startTime;
+  final String? endTime;
 
   Scene({
     this.title,
@@ -14,10 +14,8 @@ class Scene {
     this.endTime,
   });
 
-  factory Scene.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static Scene? parse(XmlElement? element) {
+    if (element == null) return null;
     return Scene(
       title: findFirstElement(element, 'sceneTitle')?.text,
       description: findFirstElement(element, 'sceneDescription')?.text,

--- a/lib/domain/media/star_rating.dart
+++ b/lib/domain/media/star_rating.dart
@@ -1,10 +1,10 @@
 import 'package:xml/xml.dart';
 
 class StarRating {
-  final double average;
-  final int count;
-  final int min;
-  final int max;
+  final double? average;
+  final int? count;
+  final int? min;
+  final int? max;
 
   StarRating({
     this.average,
@@ -13,12 +13,12 @@ class StarRating {
     this.max,
   });
 
-  factory StarRating.parse(XmlElement element) {
+  factory StarRating.parse(XmlElement? element) {
     return StarRating(
-      average: double.tryParse(element.getAttribute('average') ?? '0'),
-      count: int.tryParse(element.getAttribute('count') ?? '0'),
-      min: int.tryParse(element.getAttribute('min') ?? '0'),
-      max: int.tryParse(element.getAttribute('max') ?? '0'),
+      average: double.tryParse(element?.getAttribute('average') ?? '0'),
+      count: int.tryParse(element?.getAttribute('count') ?? '0'),
+      min: int.tryParse(element?.getAttribute('min') ?? '0'),
+      max: int.tryParse(element?.getAttribute('max') ?? '0'),
     );
   }
 }

--- a/lib/domain/media/statistics.dart
+++ b/lib/domain/media/statistics.dart
@@ -1,18 +1,18 @@
 import 'package:xml/xml.dart';
 
 class Statistics {
-  final int views;
-  final int favorites;
+  final int? views;
+  final int? favorites;
 
   Statistics({
     this.views,
     this.favorites,
   });
 
-  factory Statistics.parse(XmlElement element) {
+  factory Statistics.parse(XmlElement? element) {
     return Statistics(
-      views: int.tryParse(element.getAttribute('views') ?? '0'),
-      favorites: int.tryParse(element.getAttribute('favorites') ?? '0'),
+      views: int.tryParse(element?.getAttribute('views') ?? '0'),
+      favorites: int.tryParse(element?.getAttribute('favorites') ?? '0'),
     );
   }
 }

--- a/lib/domain/media/status.dart
+++ b/lib/domain/media/status.dart
@@ -1,18 +1,16 @@
 import 'package:xml/xml.dart';
 
 class Status {
-  final String state;
-  final String reason;
+  final String? state;
+  final String? reason;
 
   Status({
     this.state,
     this.reason,
   });
 
-  factory Status.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Status(
       state: element.getAttribute('state'),
       reason: element.getAttribute('reason'),

--- a/lib/domain/media/tags.dart
+++ b/lib/domain/media/tags.dart
@@ -1,18 +1,16 @@
 import 'package:xml/xml.dart';
 
 class Tags {
-  final String tags;
-  final int weight;
+  final String? tags;
+  final int? weight;
 
   Tags({
     this.tags,
     this.weight,
   });
 
-  factory Tags.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Tags(
       tags: element.text,
       weight: int.tryParse(element.getAttribute('weight') ?? '1'),

--- a/lib/domain/media/text.dart
+++ b/lib/domain/media/text.dart
@@ -1,11 +1,11 @@
 import 'package:xml/xml.dart';
 
 class Text {
-  final String type;
-  final String lang;
-  final String start;
-  final String end;
-  final String value;
+  final String? type;
+  final String? lang;
+  final String? start;
+  final String? end;
+  final String? value;
 
   Text({
     this.type,
@@ -15,10 +15,8 @@ class Text {
     this.value,
   });
 
-  factory Text.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Text(
       type: element.getAttribute('type'),
       lang: element.getAttribute('lang'),

--- a/lib/domain/media/thumbnail.dart
+++ b/lib/domain/media/thumbnail.dart
@@ -1,10 +1,10 @@
 import 'package:xml/xml.dart';
 
 class Thumbnail {
-  final String url;
-  final String width;
-  final String height;
-  final String time;
+  final String? url;
+  final String? width;
+  final String? height;
+  final String? time;
 
   Thumbnail({
     this.url,

--- a/lib/domain/media/title.dart
+++ b/lib/domain/media/title.dart
@@ -1,18 +1,16 @@
 import 'package:xml/xml.dart';
 
 class Title {
-  final String type;
-  final String value;
+  final String? type;
+  final String? value;
 
   Title({
     this.type,
     this.value,
   });
 
-  factory Title.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return Title(
       type: element.getAttribute('type'),
       value: element.text,

--- a/lib/domain/rss_category.dart
+++ b/lib/domain/rss_category.dart
@@ -1,15 +1,13 @@
 import 'package:xml/xml.dart';
 
 class RssCategory {
-  final String domain;
+  final String? domain;
   final String value;
 
   RssCategory(this.domain, this.value);
 
-  factory RssCategory.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static RssCategory? parse(XmlElement? element) {
+    if (element == null) return null;
     var domain = element.getAttribute('domain');
     var value = element.text;
 

--- a/lib/domain/rss_cloud.dart
+++ b/lib/domain/rss_cloud.dart
@@ -1,11 +1,11 @@
 import 'package:xml/xml.dart';
 
 class RssCloud {
-  final String domain;
-  final String port;
-  final String path;
-  final String registerProcedure;
-  final String protocol;
+  final String? domain;
+  final String? port;
+  final String? path;
+  final String? registerProcedure;
+  final String? protocol;
 
   RssCloud(
     this.domain,
@@ -15,10 +15,8 @@ class RssCloud {
     this.protocol,
   );
 
-  factory RssCloud.parse(XmlElement node) {
-    if (node == null) {
-      return null;
-    }
+  static parse(XmlElement? node) {
+    if (node == null) return null;
     var domain = node.getAttribute('domain');
     var port = node.getAttribute('port');
     var path = node.getAttribute('path');

--- a/lib/domain/rss_content.dart
+++ b/lib/domain/rss_content.dart
@@ -12,16 +12,16 @@ final _imagesRegExp = RegExp(
 ///
 class RssContent {
   String value;
-  Iterable<String> images;
+  Iterable<String?> images;
 
   RssContent(this.value, this.images);
 
-  factory RssContent.parse(XmlElement element) {
-    if (element == null) {
+  static parse(XmlElement? element) {
+    if(element == null) {
       return null;
     }
-    final content = element.text;
-    final images = <String>[];
+    final dynamic? content = element.text;
+    final images = <String?>[];
     _imagesRegExp.allMatches(content).forEach((match) {
       images.add(match.group(1));
     });

--- a/lib/domain/rss_enclosure.dart
+++ b/lib/domain/rss_enclosure.dart
@@ -1,16 +1,14 @@
 import 'package:xml/xml.dart';
 
 class RssEnclosure {
-  final String url;
-  final String type;
-  final int length;
+  final String? url;
+  final String? type;
+  final int? length;
 
   RssEnclosure(this.url, this.type, this.length);
 
-  factory RssEnclosure.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     var url = element.getAttribute('url');
     var type = element.getAttribute('type');
     var length = int.tryParse(element.getAttribute('length') ?? '0');

--- a/lib/domain/rss_feed.dart
+++ b/lib/domain/rss_feed.dart
@@ -11,29 +11,29 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class RssFeed {
-  final String title;
-  final String author;
-  final String description;
-  final String link;
-  final List<RssItem> items;
+  final String? title;
+  final String? author;
+  final String? description;
+  final String? link;
+  final List<RssItem>? items;
 
-  final RssImage image;
-  final RssCloud cloud;
-  final List<RssCategory> categories;
-  final List<String> skipDays;
-  final List<int> skipHours;
-  final String lastBuildDate;
-  final String language;
-  final String generator;
-  final String copyright;
-  final String docs;
-  final String managingEditor;
-  final String rating;
-  final String webMaster;
-  final int ttl;
-  final DublinCore dc;
-  final Itunes itunes;
-  final Syndication syndication;
+  final RssImage? image;
+  final RssCloud? cloud;
+  final List<RssCategory?>? categories;
+  final List<String>? skipDays;
+  final List<int?>? skipHours;
+  final String? lastBuildDate;
+  final String? language;
+  final String? generator;
+  final String? copyright;
+  final String? docs;
+  final String? managingEditor;
+  final String? rating;
+  final String? webMaster;
+  final int? ttl;
+  final DublinCore? dc;
+  final Itunes? itunes;
+  final Syndication? syndication;
 
   RssFeed({
     this.title,
@@ -76,7 +76,7 @@ class RssFeed {
       author: findFirstElement(channelElement, 'author')?.text,
       description: findFirstElement(channelElement, 'description')?.text,
       link: findFirstElement(channelElement, 'link')?.text,
-      items: (rss != null ? channelElement : rdf)
+      items: (rss != null ? channelElement : rdf)!
           .findElements('item')
           .map((e) => RssItem.parse(e))
           .toList(),
@@ -89,13 +89,13 @@ class RssFeed {
           .toList(),
       skipDays: findFirstElement(channelElement, 'skipDays')
               ?.findAllElements('day')
-              ?.map((e) => e.text)
-              ?.toList() ??
+              .map((e) => e.text)
+              .toList() ??
           [],
       skipHours: findFirstElement(channelElement, 'skipHours')
               ?.findAllElements('hour')
-              ?.map((e) => int.tryParse(e.text ?? '0'))
-              ?.toList() ??
+              .map((e) => int.tryParse(e.text))
+              .toList() ??
           [],
       lastBuildDate: findFirstElement(channelElement, 'lastBuildDate')?.text,
       language: findFirstElement(channelElement, 'language')?.text,

--- a/lib/domain/rss_image.dart
+++ b/lib/domain/rss_image.dart
@@ -2,16 +2,14 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class RssImage {
-  final String title;
-  final String url;
-  final String link;
+  final String? title;
+  final String? url;
+  final String? link;
 
   RssImage({this.title, this.url, this.link});
 
-  factory RssImage.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     return RssImage(
       title: findFirstElement(element, 'title')?.text,
       url: findFirstElement(element, 'url')?.text,

--- a/lib/domain/rss_item.dart
+++ b/lib/domain/rss_item.dart
@@ -10,21 +10,21 @@ import 'package:webfeed/util/xml.dart';
 import 'package:xml/xml.dart';
 
 class RssItem {
-  final String title;
-  final String description;
-  final String link;
+  final String? title;
+  final String? description;
+  final String? link;
 
-  final List<RssCategory> categories;
-  final String guid;
-  final DateTime pubDate;
-  final String author;
-  final String comments;
-  final RssSource source;
-  final RssContent content;
-  final Media media;
-  final RssEnclosure enclosure;
-  final DublinCore dc;
-  final Itunes itunes;
+  final List<RssCategory?>? categories;
+  final String? guid;
+  final DateTime? pubDate;
+  final String? author;
+  final String? comments;
+  final RssSource? source;
+  final RssContent? content;
+  final Media? media;
+  final RssEnclosure? enclosure;
+  final DublinCore? dc;
+  final Itunes? itunes;
 
   RssItem({
     this.title,

--- a/lib/domain/rss_source.dart
+++ b/lib/domain/rss_source.dart
@@ -1,15 +1,13 @@
 import 'package:xml/xml.dart';
 
 class RssSource {
-  final String url;
-  final String value;
+  final String? url;
+  final String? value;
 
   RssSource(this.url, this.value);
 
-  factory RssSource.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     var url = element.getAttribute('url');
     var value = element.text;
 

--- a/lib/domain/syndication/syndication.dart
+++ b/lib/domain/syndication/syndication.dart
@@ -5,9 +5,9 @@ import 'package:xml/xml.dart';
 enum SyndicationUpdatePeriod { hourly, daily, weekly, monthly, yearly }
 
 class Syndication {
-  final SyndicationUpdatePeriod updatePeriod;
-  final int updateFrequency;
-  final DateTime updateBase;
+  final SyndicationUpdatePeriod? updatePeriod;
+  final int? updateFrequency;
+  final DateTime? updateBase;
 
   Syndication({
     this.updatePeriod,
@@ -15,10 +15,8 @@ class Syndication {
     this.updateBase,
   });
 
-  factory Syndication.parse(XmlElement element) {
-    if (element == null) {
-      return null;
-    }
+  static parse(XmlElement? element) {
+    if (element == null) return null;
     SyndicationUpdatePeriod updatePeriod;
     switch (findFirstElement(element, 'sy:updatePeriod')?.text) {
       case 'hourly':

--- a/lib/util/datetime.dart
+++ b/lib/util/datetime.dart
@@ -2,15 +2,15 @@ import 'package:intl/intl.dart';
 
 const rfc822DatePattern = 'EEE, dd MMM yyyy HH:mm:ss Z';
 
-DateTime parseDateTime(dateString) {
+DateTime? parseDateTime(dateString) {
   if (dateString == null) return null;
   return _parseRfc822DateTime(dateString) ?? _parseIso8601DateTime(dateString);
 }
 
-DateTime _parseRfc822DateTime(String dateString) {
+DateTime? _parseRfc822DateTime(String dateString) {
   try {
-    final length = dateString?.length?.clamp(0, rfc822DatePattern.length);
-    final trimmedPattern = rfc822DatePattern.substring(0, length); //Some feeds use a shortened RFC 822 date, e.g. 'Tue, 04 Aug 2020'
+    final num? length = dateString.length.clamp(0, rfc822DatePattern.length);
+    final trimmedPattern = rfc822DatePattern.substring(0, length as int?); //Some feeds use a shortened RFC 822 date, e.g. 'Tue, 04 Aug 2020'
     final format = DateFormat(trimmedPattern, 'en_US');
     return format.parse(dateString);
   } on FormatException {
@@ -18,7 +18,7 @@ DateTime _parseRfc822DateTime(String dateString) {
   }
 }
 
-DateTime _parseIso8601DateTime(dateString) {
+DateTime? _parseIso8601DateTime(dateString) {
   try {
     return DateTime.parse(dateString);
   } on FormatException {

--- a/lib/util/xml.dart
+++ b/lib/util/xml.dart
@@ -2,11 +2,11 @@ import 'dart:core';
 
 import 'package:xml/xml.dart';
 
-XmlElement findFirstElement(
-  XmlNode node,
+XmlElement? findFirstElement(
+  XmlNode? node,
   String name, {
   bool recursive = false,
-  String namespace,
+  String? namespace,
 }) {
   try {
     return findElements(node, name, recursive: recursive, namespace: namespace)
@@ -16,17 +16,17 @@ XmlElement findFirstElement(
   }
 }
 
-Iterable<XmlElement> findElements(
-  XmlNode node,
+Iterable<XmlElement>? findElements(
+  XmlNode? node,
   String name, {
   bool recursive = false,
-  String namespace,
+  String? namespace,
 }) {
   try {
     if (recursive) {
-      return node.findAllElements(name, namespace: namespace);
+      return node?.findAllElements(name, namespace: namespace);
     } else {
-      return node.findElements(name, namespace: namespace);
+      return node?.findElements(name, namespace: namespace);
     }
   } on StateError {
     return null;
@@ -34,7 +34,7 @@ Iterable<XmlElement> findElements(
 }
 
 bool parseBoolLiteral(XmlElement element, String tagName) {
-  var v = findFirstElement(element, tagName)?.text?.toLowerCase()?.trim();
+  var v = findFirstElement(element, tagName)?.text.toLowerCase().trim();
   if (v == null) return false;
   return ['yes', 'true'].contains(v);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,10 @@ version: 0.6.0
 description: webfeed is a dart package for parsing RSS and Atom feeds. Media, DublinCore, iTunes, Syndication namespaces are also supported.
 homepage: https://github.com/witochandra/webfeed
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  xml: "^4.2.0"
-  intl: "^0.16.0"
+  xml: "^5.0.2"
+  intl: "^0.17.0"
 dev_dependencies:
   test: ^1.3.0
-  http: "^0.11.3+16"
+  http: "^0.13.0"

--- a/test/atom_test.dart
+++ b/test/atom_test.dart
@@ -23,65 +23,65 @@ void main() {
     expect(feed.title, 'Foo bar news');
     expect(feed.updated, DateTime.utc(2018, 4, 6, 13, 2, 46));
 
-    expect(feed.links.length, 2);
-    expect(feed.links.first.rel, 'foo');
-    expect(feed.links.first.type, 'text/html');
-    expect(feed.links.first.hreflang, 'en');
-    expect(feed.links.first.href, 'http://foo.bar.news/');
-    expect(feed.links.first.title, 'Foo bar news html');
-    expect(feed.links.first.length, 1000);
+    expect(feed.links!.length, 2);
+    expect(feed.links!.first.rel, 'foo');
+    expect(feed.links!.first.type, 'text/html');
+    expect(feed.links!.first.hreflang, 'en');
+    expect(feed.links!.first.href, 'http://foo.bar.news/');
+    expect(feed.links!.first.title, 'Foo bar news html');
+    expect(feed.links!.first.length, 1000);
 
-    expect(feed.authors.length, 2);
-    expect(feed.authors.first.name, 'Alice');
-    expect(feed.authors.first.uri, 'http://foo.bar.news/people/alice');
-    expect(feed.authors.first.email, 'alice@foo.bar.news');
+    expect(feed.authors!.length, 2);
+    expect(feed.authors!.first.name, 'Alice');
+    expect(feed.authors!.first.uri, 'http://foo.bar.news/people/alice');
+    expect(feed.authors!.first.email, 'alice@foo.bar.news');
 
-    expect(feed.contributors.length, 2);
-    expect(feed.contributors.first.name, 'Charlie');
-    expect(feed.contributors.first.uri, 'http://foo.bar.news/people/charlie');
-    expect(feed.contributors.first.email, 'charlie@foo.bar.news');
+    expect(feed.contributors!.length, 2);
+    expect(feed.contributors!.first.name, 'Charlie');
+    expect(feed.contributors!.first.uri, 'http://foo.bar.news/people/charlie');
+    expect(feed.contributors!.first.email, 'charlie@foo.bar.news');
 
-    expect(feed.categories.length, 2);
-    expect(feed.categories.first.term, 'foo category');
-    expect(feed.categories.first.scheme, 'this-is-foo-scheme');
-    expect(feed.categories.first.label, 'this is foo label');
+    expect(feed.categories!.length, 2);
+    expect(feed.categories!.first.term, 'foo category');
+    expect(feed.categories!.first.scheme, 'this-is-foo-scheme');
+    expect(feed.categories!.first.label, 'this is foo label');
 
-    expect(feed.generator.uri, 'http://foo.bar.news/generator');
-    expect(feed.generator.version, '1.0');
-    expect(feed.generator.value, 'Foo bar generator');
+    expect(feed.generator!.uri, 'http://foo.bar.news/generator');
+    expect(feed.generator!.version, '1.0');
+    expect(feed.generator!.value, 'Foo bar generator');
 
     expect(feed.icon, 'http://foo.bar.news/icon.png');
     expect(feed.logo, 'http://foo.bar.news/logo.png');
     expect(feed.subtitle, 'This is subtitle');
 
-    expect(feed.items.length, 2);
-    var item = feed.items.first;
+    expect(feed.items!.length, 2);
+    var item = feed.items!.first;
     expect(item.id, 'foo-bar-entry-id-1');
     expect(item.title, 'Foo bar item 1');
     expect(item.updated, DateTime.utc(2018, 4, 6, 13, 2, 40));
 
-    expect(item.authors.length, 2);
-    expect(item.authors.first.name, 'Ellie');
-    expect(item.authors.first.uri, 'http://foo.bar.news/people/ellie');
-    expect(item.authors.first.email, 'ellie@foo.bar.news');
+    expect(item.authors!.length, 2);
+    expect(item.authors!.first.name, 'Ellie');
+    expect(item.authors!.first.uri, 'http://foo.bar.news/people/ellie');
+    expect(item.authors!.first.email, 'ellie@foo.bar.news');
 
-    expect(item.links.length, 2);
-    expect(item.links.first.rel, 'foo entry');
-    expect(item.links.first.type, 'text/html');
-    expect(item.links.first.hreflang, 'en');
-    expect(item.links.first.href, 'http://foo.bar.news/entry');
-    expect(item.links.first.title, 'Foo bar news html');
-    expect(item.links.first.length, 1000);
+    expect(item.links!.length, 2);
+    expect(item.links!.first.rel, 'foo entry');
+    expect(item.links!.first.type, 'text/html');
+    expect(item.links!.first.hreflang, 'en');
+    expect(item.links!.first.href, 'http://foo.bar.news/entry');
+    expect(item.links!.first.title, 'Foo bar news html');
+    expect(item.links!.first.length, 1000);
 
-    expect(item.categories.length, 2);
-    expect(item.categories.first.term, 'foo entry category');
-    expect(item.categories.first.scheme, 'this-is-foo-entry-scheme');
-    expect(item.categories.first.label, 'this is foo entry label');
+    expect(item.categories!.length, 2);
+    expect(item.categories!.first.term, 'foo entry category');
+    expect(item.categories!.first.scheme, 'this-is-foo-entry-scheme');
+    expect(item.categories!.first.label, 'this is foo entry label');
 
-    expect(item.contributors.length, 2);
-    expect(item.contributors.first.name, 'Gin');
-    expect(item.contributors.first.uri, 'http://foo.bar.news/people/gin');
-    expect(item.contributors.first.email, 'gin@foo.bar.news');
+    expect(item.contributors!.length, 2);
+    expect(item.contributors!.first.name, 'Gin');
+    expect(item.contributors!.first.uri, 'http://foo.bar.news/people/gin');
+    expect(item.contributors!.first.email, 'gin@foo.bar.news');
 
     expect(item.published, '2018-04-06T13:02:49Z');
     expect(item.summary, 'This is summary 1');
@@ -96,16 +96,16 @@ void main() {
     expect(feed.title, 'Foo bar news');
     expect(feed.updated, DateTime.utc(2018, 4, 6, 13, 2, 46));
 
-    expect(feed.items.length, 1);
+    expect(feed.items!.length, 1);
 
-    var item = feed.items.first;
-    expect(item.media.group.contents.length, 5);
-    expect(item.media.group.credits.length, 2);
-    expect(item.media.group.category.value, 'music/artist name/album/song');
-    expect(item.media.group.rating.value, 'nonadult');
+    var item = feed.items!.first;
+    expect(item.media!.group!.contents!.length, 5);
+    expect(item.media!.group!.credits!.length, 2);
+    expect(item.media!.group!.category!.value, 'music/artist name/album/song');
+    expect(item.media!.group!.rating!.value, 'nonadult');
 
-    expect(item.media.contents.length, 2);
-    var mediaContent = item.media.contents.first;
+    expect(item.media!.contents!.length, 2);
+    var mediaContent = item.media!.contents!.first;
     expect(mediaContent.url, 'http://www.foo.com/video.mov');
     expect(mediaContent.type, 'video/quicktime');
     expect(mediaContent.fileSize, 2000);
@@ -117,111 +117,111 @@ void main() {
     expect(mediaContent.samplingrate, 44.1);
     expect(mediaContent.channels, 2);
 
-    expect(item.media.credits.length, 2);
-    var mediaCredit = item.media.credits.first;
+    expect(item.media!.credits!.length, 2);
+    var mediaCredit = item.media!.credits!.first;
     expect(mediaCredit.role, 'owner1');
     expect(mediaCredit.scheme, 'urn:yvs');
     expect(mediaCredit.value, 'copyright holder of the entity');
 
-    expect(item.media.category.scheme,
+    expect(item.media!.category!.scheme,
         'http://search.yahoo.com/mrss/category_ schema');
-    expect(item.media.category.label, 'Music');
-    expect(item.media.category.value, 'music/artist/album/song');
+    expect(item.media!.category!.label, 'Music');
+    expect(item.media!.category!.value, 'music/artist/album/song');
 
-    expect(item.media.rating.scheme, 'urn:simple');
-    expect(item.media.rating.value, 'adult');
+    expect(item.media!.rating!.scheme, 'urn:simple');
+    expect(item.media!.rating!.value, 'adult');
 
-    expect(item.media.title.type, 'plain');
-    expect(item.media.title.value, "The Judy's -- The Moo Song");
+    expect(item.media!.title!.type, 'plain');
+    expect(item.media!.title!.value, "The Judy's -- The Moo Song");
 
-    expect(item.media.description.type, 'plain');
-    expect(item.media.description.value,
+    expect(item.media!.description!.type, 'plain');
+    expect(item.media!.description!.value,
         'This was some really bizarre band I listened to as a young lad.');
 
-    expect(item.media.keywords, 'kitty, cat, big dog, yarn, fluffy');
+    expect(item.media!.keywords, 'kitty, cat, big dog, yarn, fluffy');
 
-    expect(item.media.thumbnails.length, 2);
-    var mediaThumbnail = item.media.thumbnails.first;
+    expect(item.media!.thumbnails!.length, 2);
+    var mediaThumbnail = item.media!.thumbnails!.first;
     expect(mediaThumbnail.url, 'http://www.foo.com/keyframe1.jpg');
     expect(mediaThumbnail.width, '75');
     expect(mediaThumbnail.height, '50');
     expect(mediaThumbnail.time, '12:05:01.123');
 
-    expect(item.media.hash.algo, 'md5');
-    expect(item.media.hash.value, 'dfdec888b72151965a34b4b59031290a');
+    expect(item.media!.hash!.algo, 'md5');
+    expect(item.media!.hash!.value, 'dfdec888b72151965a34b4b59031290a');
 
-    expect(item.media.player.url, 'http://www.foo.com/player?id=1111');
-    expect(item.media.player.width, 400);
-    expect(item.media.player.height, 200);
-    expect(item.media.player.value, '');
+    expect(item.media!.player!.url, 'http://www.foo.com/player?id=1111');
+    expect(item.media!.player!.width, 400);
+    expect(item.media!.player!.height, 200);
+    expect(item.media!.player!.value, '');
 
-    expect(item.media.copyright.url, 'http://blah.com/additional-info.html');
-    expect(item.media.copyright.value, '2005 FooBar Media');
+    expect(item.media!.copyright!.url, 'http://blah.com/additional-info.html');
+    expect(item.media!.copyright!.value, '2005 FooBar Media');
 
-    expect(item.media.text.type, 'plain');
-    expect(item.media.text.lang, 'en');
-    expect(item.media.text.start, '00:00:03.000');
-    expect(item.media.text.end, '00:00:10.000');
-    expect(item.media.text.value, ' Oh, say, can you see');
+    expect(item.media!.text!.type, 'plain');
+    expect(item.media!.text!.lang, 'en');
+    expect(item.media!.text!.start, '00:00:03.000');
+    expect(item.media!.text!.end, '00:00:10.000');
+    expect(item.media!.text!.value, ' Oh, say, can you see');
 
-    expect(item.media.restriction.relationship, 'allow');
-    expect(item.media.restriction.type, 'country');
-    expect(item.media.restriction.value, 'au us');
+    expect(item.media!.restriction!.relationship, 'allow');
+    expect(item.media!.restriction!.type, 'country');
+    expect(item.media!.restriction!.value, 'au us');
 
-    expect(item.media.community.starRating.average, 3.5);
-    expect(item.media.community.starRating.count, 20);
-    expect(item.media.community.starRating.min, 1);
-    expect(item.media.community.starRating.max, 10);
-    expect(item.media.community.statistics.views, 5);
-    expect(item.media.community.statistics.favorites, 4);
-    expect(item.media.community.tags.tags, 'news: 5, abc:3');
-    expect(item.media.community.tags.weight, 1);
+    expect(item.media!.community!.starRating!.average, 3.5);
+    expect(item.media!.community!.starRating!.count, 20);
+    expect(item.media!.community!.starRating!.min, 1);
+    expect(item.media!.community!.starRating!.max, 10);
+    expect(item.media!.community!.statistics!.views, 5);
+    expect(item.media!.community!.statistics!.favorites, 4);
+    expect(item.media!.community!.tags!.tags, 'news: 5, abc:3');
+    expect(item.media!.community!.tags!.weight, 1);
 
-    expect(item.media.comments.length, 2);
-    expect(item.media.comments.first, 'comment1');
-    expect(item.media.comments.last, 'comment2');
+    expect(item.media!.comments!.length, 2);
+    expect(item.media!.comments!.first, 'comment1');
+    expect(item.media!.comments!.last, 'comment2');
 
-    expect(item.media.embed.url, 'http://www.foo.com/player.swf');
-    expect(item.media.embed.width, 512);
-    expect(item.media.embed.height, 323);
-    expect(item.media.embed.params.length, 5);
-    expect(item.media.embed.params.first.name, 'type');
+    expect(item.media!.embed!.url, 'http://www.foo.com/player.swf');
+    expect(item.media!.embed!.width, 512);
+    expect(item.media!.embed!.height, 323);
+    expect(item.media!.embed!.params!.length, 5);
+    expect(item.media!.embed!.params!.first!.name, 'type');
     expect(
-        item.media.embed.params.first.value, 'application/x-shockwave-flash');
+        item.media!.embed!.params!.first!.value, 'application/x-shockwave-flash');
 
-    expect(item.media.responses.length, 2);
-    expect(item.media.responses.first, 'http://www.response1.com');
-    expect(item.media.responses.last, 'http://www.response2.com');
+    expect(item.media!.responses!.length, 2);
+    expect(item.media!.responses!.first, 'http://www.response1.com');
+    expect(item.media!.responses!.last, 'http://www.response2.com');
 
-    expect(item.media.backLinks.length, 2);
-    expect(item.media.backLinks.first, 'http://www.backlink1.com');
-    expect(item.media.backLinks.last, 'http://www.backlink2.com');
+    expect(item.media!.backLinks!.length, 2);
+    expect(item.media!.backLinks!.first, 'http://www.backlink1.com');
+    expect(item.media!.backLinks!.last, 'http://www.backlink2.com');
 
-    expect(item.media.status.state, 'active');
-    expect(item.media.status.reason, null);
+    expect(item.media!.status!.state, 'active');
+    expect(item.media!.status!.reason, null);
 
-    expect(item.media.prices.length, 2);
-    expect(item.media.prices.first.price, 19.99);
-    expect(item.media.prices.first.type, 'rent');
+    expect(item.media!.prices!.length, 2);
+    expect(item.media!.prices!.first.price, 19.99);
+    expect(item.media!.prices!.first.type, 'rent');
     expect(
-        item.media.prices.first.info, 'http://www.dummy.jp/package_info.html');
-    expect(item.media.prices.first.currency, 'EUR');
+        item.media!.prices!.first.info, 'http://www.dummy.jp/package_info.html');
+    expect(item.media!.prices!.first.currency, 'EUR');
 
-    expect(item.media.license.type, 'text/html');
-    expect(item.media.license.href, 'http://www.licensehost.com/license');
-    expect(item.media.license.value, ' Sample license for a video');
+    expect(item.media!.license!.type, 'text/html');
+    expect(item.media!.license!.href, 'http://www.licensehost.com/license');
+    expect(item.media!.license!.value, ' Sample license for a video');
 
-    expect(item.media.peerLink.type, 'application/x-bittorrent');
-    expect(item.media.peerLink.href, 'http://www.foo.org/sampleFile.torrent');
-    expect(item.media.peerLink.value, '');
+    expect(item.media!.peerLink!.type, 'application/x-bittorrent');
+    expect(item.media!.peerLink!.href, 'http://www.foo.org/sampleFile.torrent');
+    expect(item.media!.peerLink!.value, '');
 
-    expect(item.media.rights.status, 'official');
+    expect(item.media!.rights!.status, 'official');
 
-    expect(item.media.scenes.length, 2);
-    expect(item.media.scenes.first.title, 'sceneTitle1');
-    expect(item.media.scenes.first.description, 'sceneDesc1');
-    expect(item.media.scenes.first.startTime, '00:15');
-    expect(item.media.scenes.first.endTime, '00:45');
+    expect(item.media!.scenes!.length, 2);
+    expect(item.media!.scenes!.first!.title, 'sceneTitle1');
+    expect(item.media!.scenes!.first!.description, 'sceneDesc1');
+    expect(item.media!.scenes!.first!.startTime, '00:15');
+    expect(item.media!.scenes!.first!.endTime, '00:45');
   });
 
   test('parse Atom-Empty.xml', () {
@@ -232,25 +232,25 @@ void main() {
     expect(feed.id, null);
     expect(feed.title, null);
     expect(feed.updated, null);
-    expect(feed.links.length, 0);
-    expect(feed.authors.length, 0);
-    expect(feed.contributors.length, 0);
-    expect(feed.categories.length, 0);
+    expect(feed.links!.length, 0);
+    expect(feed.authors!.length, 0);
+    expect(feed.contributors!.length, 0);
+    expect(feed.categories!.length, 0);
     expect(feed.generator, null);
     expect(feed.icon, null);
     expect(feed.logo, null);
     expect(feed.subtitle, null);
 
-    expect(feed.items.length, 1);
-    var item = feed.items.first;
+    expect(feed.items!.length, 1);
+    var item = feed.items!.first;
 
-    expect(item.authors.length, 0);
+    expect(item.authors!.length, 0);
 
-    expect(item.links.length, 0);
+    expect(item.links!.length, 0);
 
-    expect(item.categories.length, 0);
+    expect(item.categories!.length, 0);
 
-    expect(item.contributors.length, 0);
+    expect(item.contributors!.length, 0);
 
     expect(item.published, null);
     expect(item.summary, null);

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -36,59 +36,59 @@ void main() {
     expect(feed.webMaster, 'webmaster@foo.bar.news');
     expect(feed.ttl, 60);
 
-    expect(feed.image.title, 'Foo bar News');
-    expect(feed.image.url, 'https://foo.bar.news/logo.gif');
-    expect(feed.image.link, 'https://foo.bar.news/');
+    expect(feed.image!.title, 'Foo bar News');
+    expect(feed.image!.url, 'https://foo.bar.news/logo.gif');
+    expect(feed.image!.link, 'https://foo.bar.news/');
 
-    expect(feed.cloud.domain, 'radio.foo.bar.news');
-    expect(feed.cloud.port, '80');
-    expect(feed.cloud.path, '/RPC2');
-    expect(feed.cloud.registerProcedure, 'foo.bar.rssPleaseNotify');
-    expect(feed.cloud.protocol, 'xml-rpc');
+    expect(feed.cloud!.domain, 'radio.foo.bar.news');
+    expect(feed.cloud!.port, '80');
+    expect(feed.cloud!.path, '/RPC2');
+    expect(feed.cloud!.registerProcedure, 'foo.bar.rssPleaseNotify');
+    expect(feed.cloud!.protocol, 'xml-rpc');
 
-    expect(feed.categories.length, 2);
-    expect(feed.categories[0].domain, null);
-    expect(feed.categories[0].value, 'Ipsum');
-    expect(feed.categories[1].domain, 'news');
-    expect(feed.categories[1].value, 'Lorem Ipsum');
+    expect(feed.categories!.length, 2);
+    expect(feed.categories![0]!.domain, null);
+    expect(feed.categories![0]!.value, 'Ipsum');
+    expect(feed.categories![1]!.domain, 'news');
+    expect(feed.categories![1]!.value, 'Lorem Ipsum');
 
-    expect(feed.skipDays.length, 3);
-    expect(feed.skipDays.contains('Monday'), true);
-    expect(feed.skipDays.contains('Tuesday'), true);
-    expect(feed.skipDays.contains('Sunday'), true);
+    expect(feed.skipDays!.length, 3);
+    expect(feed.skipDays!.contains('Monday'), true);
+    expect(feed.skipDays!.contains('Tuesday'), true);
+    expect(feed.skipDays!.contains('Sunday'), true);
 
-    expect(feed.skipHours.length, 5);
-    expect(feed.skipHours.contains(0), true);
-    expect(feed.skipHours.contains(1), true);
-    expect(feed.skipHours.contains(2), true);
-    expect(feed.skipHours.contains(3), true);
-    expect(feed.skipHours.contains(4), true);
+    expect(feed.skipHours!.length, 5);
+    expect(feed.skipHours!.contains(0), true);
+    expect(feed.skipHours!.contains(1), true);
+    expect(feed.skipHours!.contains(2), true);
+    expect(feed.skipHours!.contains(3), true);
+    expect(feed.skipHours!.contains(4), true);
 
-    expect(feed.items.length, 2);
+    expect(feed.items!.length, 2);
 
-    expect(feed.items.first.title,
+    expect(feed.items!.first.title,
         'The standard Lorem Ipsum passage, used since the 1500s');
-    expect(feed.items.first.description,
+    expect(feed.items!.first.description,
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit');
-    expect(feed.items.first.link, 'https://foo.bar.news/1');
-    expect(feed.items.first.guid, 'https://foo.bar.news/1?guid');
-    expect(feed.items.first.pubDate,
+    expect(feed.items!.first.link, 'https://foo.bar.news/1');
+    expect(feed.items!.first.guid, 'https://foo.bar.news/1?guid');
+    expect(feed.items!.first.pubDate,
         DateTime(2018, 03, 26, 14)); //Mon, 26 Mar 2018 14:00:00 PDT
-    expect(feed.items.first.categories.first.domain, 'news');
-    expect(feed.items.first.categories.first.value, 'Lorem');
-    expect(feed.items.first.author, 'alice@foo.bar.news');
-    expect(feed.items.first.source.url, 'https://foo.bar.news/1?source');
-    expect(feed.items.first.source.value, 'Foo Bar');
-    expect(feed.items.first.comments, 'https://foo.bar.news/1/comments');
-    expect(feed.items.first.enclosure.url,
+    expect(feed.items!.first.categories!.first!.domain, 'news');
+    expect(feed.items!.first.categories!.first!.value, 'Lorem');
+    expect(feed.items!.first.author, 'alice@foo.bar.news');
+    expect(feed.items!.first.source!.url, 'https://foo.bar.news/1?source');
+    expect(feed.items!.first.source!.value, 'Foo Bar');
+    expect(feed.items!.first.comments, 'https://foo.bar.news/1/comments');
+    expect(feed.items!.first.enclosure!.url,
         'http://www.scripting.com/mp3s/weatherReportSuite.mp3');
-    expect(feed.items.first.enclosure.length, 12216320);
-    expect(feed.items.first.enclosure.type, 'audio/mpeg');
+    expect(feed.items!.first.enclosure!.length, 12216320);
+    expect(feed.items!.first.enclosure!.type, 'audio/mpeg');
 
-    expect(feed.items.first.content.value,
+    expect(feed.items!.first.content!.value,
         '<img width="1000" height="690" src="https://test.com/image_link"/> Test content<br />');
     expect(
-        feed.items.first.content.images.first, 'https://test.com/image_link');
+        feed.items!.first.content!.images.first, 'https://test.com/image_link');
   });
   test('parse RSS-Media.xml', () {
     var xmlString = File('test/xml/RSS-Media.xml').readAsStringSync();
@@ -98,21 +98,21 @@ void main() {
     expect(
         feed.description, 'Media RSS example with new fields added in v1.5.0');
 
-    expect(feed.items.length, 1);
+    expect(feed.items!.length, 1);
 
-    var item = feed.items.first;
+    var item = feed.items!.first;
     expect(item.title, null);
     expect(item.link, 'http://www.foo.com');
     expect(item.pubDate,
         DateTime(2001, 08, 27, 16, 08, 56)); //Mon, 27 Aug 2001 16:08:56 PST
 
-    expect(item.media.group.contents.length, 5);
-    expect(item.media.group.credits.length, 2);
-    expect(item.media.group.category.value, 'music/artist name/album/song');
-    expect(item.media.group.rating.value, 'nonadult');
+    expect(item.media!.group!.contents!.length, 5);
+    expect(item.media!.group!.credits!.length, 2);
+    expect(item.media!.group!.category!.value, 'music/artist name/album/song');
+    expect(item.media!.group!.rating!.value, 'nonadult');
 
-    expect(item.media.contents.length, 2);
-    var mediaContent = item.media.contents.first;
+    expect(item.media!.contents!.length, 2);
+    var mediaContent = item.media!.contents!.first;
     expect(mediaContent.url, 'http://www.foo.com/video.mov');
     expect(mediaContent.type, 'video/quicktime');
     expect(mediaContent.fileSize, 2000);
@@ -124,152 +124,152 @@ void main() {
     expect(mediaContent.samplingrate, 44.1);
     expect(mediaContent.channels, 2);
 
-    expect(item.media.credits.length, 2);
-    var mediaCredit = item.media.credits.first;
+    expect(item.media!.credits!.length, 2);
+    var mediaCredit = item.media!.credits!.first;
     expect(mediaCredit.role, 'owner1');
     expect(mediaCredit.scheme, 'urn:yvs');
     expect(mediaCredit.value, 'copyright holder of the entity');
 
-    expect(item.media.category.scheme,
+    expect(item.media!.category!.scheme,
         'http://search.yahoo.com/mrss/category_ schema');
-    expect(item.media.category.label, 'Music');
-    expect(item.media.category.value, 'music/artist/album/song');
+    expect(item.media!.category!.label, 'Music');
+    expect(item.media!.category!.value, 'music/artist/album/song');
 
-    expect(item.media.rating.scheme, 'urn:simple');
-    expect(item.media.rating.value, 'adult');
+    expect(item.media!.rating!.scheme, 'urn:simple');
+    expect(item.media!.rating!.value, 'adult');
 
-    expect(item.media.title.type, 'plain');
-    expect(item.media.title.value, "The Judy's -- The Moo Song");
+    expect(item.media!.title!.type, 'plain');
+    expect(item.media!.title!.value, "The Judy's -- The Moo Song");
 
-    expect(item.media.description.type, 'plain');
-    expect(item.media.description.value,
+    expect(item.media!.description!.type, 'plain');
+    expect(item.media!.description!.value,
         'This was some really bizarre band I listened to as a young lad.');
 
-    expect(item.media.keywords, 'kitty, cat, big dog, yarn, fluffy');
+    expect(item.media!.keywords, 'kitty, cat, big dog, yarn, fluffy');
 
-    expect(item.media.thumbnails.length, 2);
-    var mediaThumbnail = item.media.thumbnails.first;
+    expect(item.media!.thumbnails!.length, 2);
+    var mediaThumbnail = item.media!.thumbnails!.first;
     expect(mediaThumbnail.url, 'http://www.foo.com/keyframe1.jpg');
     expect(mediaThumbnail.width, '75');
     expect(mediaThumbnail.height, '50');
     expect(mediaThumbnail.time, '12:05:01.123');
 
-    expect(item.media.hash.algo, 'md5');
-    expect(item.media.hash.value, 'dfdec888b72151965a34b4b59031290a');
+    expect(item.media!.hash!.algo, 'md5');
+    expect(item.media!.hash!.value, 'dfdec888b72151965a34b4b59031290a');
 
-    expect(item.media.player.url, 'http://www.foo.com/player?id=1111');
-    expect(item.media.player.width, 400);
-    expect(item.media.player.height, 200);
-    expect(item.media.player.value, '');
+    expect(item.media!.player!.url, 'http://www.foo.com/player?id=1111');
+    expect(item.media!.player!.width, 400);
+    expect(item.media!.player!.height, 200);
+    expect(item.media!.player!.value, '');
 
-    expect(item.media.copyright.url, 'http://blah.com/additional-info.html');
-    expect(item.media.copyright.value, '2005 FooBar Media');
+    expect(item.media!.copyright!.url, 'http://blah.com/additional-info.html');
+    expect(item.media!.copyright!.value, '2005 FooBar Media');
 
-    expect(item.media.text.type, 'plain');
-    expect(item.media.text.lang, 'en');
-    expect(item.media.text.start, '00:00:03.000');
-    expect(item.media.text.end, '00:00:10.000');
-    expect(item.media.text.value, ' Oh, say, can you see');
+    expect(item.media!.text!.type, 'plain');
+    expect(item.media!.text!.lang, 'en');
+    expect(item.media!.text!.start, '00:00:03.000');
+    expect(item.media!.text!.end, '00:00:10.000');
+    expect(item.media!.text!.value, ' Oh, say, can you see');
 
-    expect(item.media.restriction.relationship, 'allow');
-    expect(item.media.restriction.type, 'country');
-    expect(item.media.restriction.value, 'au us');
+    expect(item.media!.restriction!.relationship, 'allow');
+    expect(item.media!.restriction!.type, 'country');
+    expect(item.media!.restriction!.value, 'au us');
 
-    expect(item.media.community.starRating.average, 3.5);
-    expect(item.media.community.starRating.count, 20);
-    expect(item.media.community.starRating.min, 1);
-    expect(item.media.community.starRating.max, 10);
-    expect(item.media.community.statistics.views, 5);
-    expect(item.media.community.statistics.favorites, 4);
-    expect(item.media.community.tags.tags, 'news: 5, abc:3');
-    expect(item.media.community.tags.weight, 1);
+    expect(item.media!.community!.starRating!.average, 3.5);
+    expect(item.media!.community!.starRating!.count, 20);
+    expect(item.media!.community!.starRating!.min, 1);
+    expect(item.media!.community!.starRating!.max, 10);
+    expect(item.media!.community!.statistics!.views, 5);
+    expect(item.media!.community!.statistics!.favorites, 4);
+    expect(item.media!.community!.tags!.tags, 'news: 5, abc:3');
+    expect(item.media!.community!.tags!.weight, 1);
 
-    expect(item.media.comments.length, 2);
-    expect(item.media.comments.first, 'comment1');
-    expect(item.media.comments.last, 'comment2');
+    expect(item.media!.comments!.length, 2);
+    expect(item.media!.comments!.first, 'comment1');
+    expect(item.media!.comments!.last, 'comment2');
 
-    expect(item.media.embed.url, 'http://www.foo.com/player.swf');
-    expect(item.media.embed.width, 512);
-    expect(item.media.embed.height, 323);
-    expect(item.media.embed.params.length, 5);
-    expect(item.media.embed.params.first.name, 'type');
+    expect(item.media!.embed!.url, 'http://www.foo.com/player.swf');
+    expect(item.media!.embed!.width, 512);
+    expect(item.media!.embed!.height, 323);
+    expect(item.media!.embed!.params!.length, 5);
+    expect(item.media!.embed!.params!.first!.name, 'type');
     expect(
-        item.media.embed.params.first.value, 'application/x-shockwave-flash');
+        item.media!.embed!.params!.first!.value, 'application/x-shockwave-flash');
 
-    expect(item.media.responses.length, 2);
-    expect(item.media.responses.first, 'http://www.response1.com');
-    expect(item.media.responses.last, 'http://www.response2.com');
+    expect(item.media!.responses!.length, 2);
+    expect(item.media!.responses!.first, 'http://www.response1.com');
+    expect(item.media!.responses!.last, 'http://www.response2.com');
 
-    expect(item.media.backLinks.length, 2);
-    expect(item.media.backLinks.first, 'http://www.backlink1.com');
-    expect(item.media.backLinks.last, 'http://www.backlink2.com');
+    expect(item.media!.backLinks!.length, 2);
+    expect(item.media!.backLinks!.first, 'http://www.backlink1.com');
+    expect(item.media!.backLinks!.last, 'http://www.backlink2.com');
 
-    expect(item.media.status.state, 'active');
-    expect(item.media.status.reason, null);
+    expect(item.media!.status!.state, 'active');
+    expect(item.media!.status!.reason, null);
 
-    expect(item.media.prices.length, 2);
-    expect(item.media.prices.first.price, 19.99);
-    expect(item.media.prices.first.type, 'rent');
+    expect(item.media!.prices!.length, 2);
+    expect(item.media!.prices!.first.price, 19.99);
+    expect(item.media!.prices!.first.type, 'rent');
     expect(
-        item.media.prices.first.info, 'http://www.dummy.jp/package_info.html');
-    expect(item.media.prices.first.currency, 'EUR');
+        item.media!.prices!.first.info, 'http://www.dummy.jp/package_info.html');
+    expect(item.media!.prices!.first.currency, 'EUR');
 
-    expect(item.media.license.type, 'text/html');
-    expect(item.media.license.href, 'http://www.licensehost.com/license');
-    expect(item.media.license.value, ' Sample license for a video');
+    expect(item.media!.license!.type, 'text/html');
+    expect(item.media!.license!.href, 'http://www.licensehost.com/license');
+    expect(item.media!.license!.value, ' Sample license for a video');
 
-    expect(item.media.peerLink.type, 'application/x-bittorrent');
-    expect(item.media.peerLink.href, 'http://www.foo.org/sampleFile.torrent');
-    expect(item.media.peerLink.value, '');
+    expect(item.media!.peerLink!.type, 'application/x-bittorrent');
+    expect(item.media!.peerLink!.href, 'http://www.foo.org/sampleFile.torrent');
+    expect(item.media!.peerLink!.value, '');
 
-    expect(item.media.rights.status, 'official');
+    expect(item.media!.rights!.status, 'official');
 
-    expect(item.media.scenes.length, 2);
-    expect(item.media.scenes.first.title, 'sceneTitle1');
-    expect(item.media.scenes.first.description, 'sceneDesc1');
-    expect(item.media.scenes.first.startTime, '00:15');
-    expect(item.media.scenes.first.endTime, '00:45');
+    expect(item.media!.scenes!.length, 2);
+    expect(item.media!.scenes!.first!.title, 'sceneTitle1');
+    expect(item.media!.scenes!.first!.description, 'sceneDesc1');
+    expect(item.media!.scenes!.first!.startTime, '00:15');
+    expect(item.media!.scenes!.first!.endTime, '00:45');
   });
   test('parse RSS-DC.xml', () {
     var xmlString = File('test/xml/RSS-DC.xml').readAsStringSync();
 
     var feed = RssFeed.parse(xmlString);
 
-    expect(feed.dc.title, 'title');
-    expect(feed.dc.creator, 'creator');
-    expect(feed.dc.subject, 'subject');
-    expect(feed.dc.description, 'description');
-    expect(feed.dc.publisher, 'publisher');
-    expect(feed.dc.contributor, 'contributor');
-    expect(feed.dc.date, DateTime.utc(2000, 1, 1, 12));
-    expect(feed.dc.created, DateTime.utc(2000, 1, 1, 13));
-    expect(feed.dc.modified, DateTime.utc(2000, 1, 1, 14));
-    expect(feed.dc.type, 'type');
-    expect(feed.dc.format, 'format');
-    expect(feed.dc.identifier, 'identifier');
-    expect(feed.dc.source, 'source');
-    expect(feed.dc.language, 'language');
-    expect(feed.dc.relation, 'relation');
-    expect(feed.dc.coverage, 'coverage');
-    expect(feed.dc.rights, 'rights');
+    expect(feed.dc!.title, 'title');
+    expect(feed.dc!.creator, 'creator');
+    expect(feed.dc!.subject, 'subject');
+    expect(feed.dc!.description, 'description');
+    expect(feed.dc!.publisher, 'publisher');
+    expect(feed.dc!.contributor, 'contributor');
+    expect(feed.dc!.date, DateTime.utc(2000, 1, 1, 12));
+    expect(feed.dc!.created, DateTime.utc(2000, 1, 1, 13));
+    expect(feed.dc!.modified, DateTime.utc(2000, 1, 1, 14));
+    expect(feed.dc!.type, 'type');
+    expect(feed.dc!.format, 'format');
+    expect(feed.dc!.identifier, 'identifier');
+    expect(feed.dc!.source, 'source');
+    expect(feed.dc!.language, 'language');
+    expect(feed.dc!.relation, 'relation');
+    expect(feed.dc!.coverage, 'coverage');
+    expect(feed.dc!.rights, 'rights');
 
-    expect(feed.items.first.dc.title, 'title');
-    expect(feed.items.first.dc.creator, 'creator');
-    expect(feed.items.first.dc.subject, 'subject');
-    expect(feed.items.first.dc.description, 'description');
-    expect(feed.items.first.dc.publisher, 'publisher');
-    expect(feed.items.first.dc.contributor, 'contributor');
-    expect(feed.items.first.dc.date, DateTime.utc(2000, 1, 2, 12));
-    expect(feed.items.first.dc.created, DateTime.utc(2000, 1, 2, 13));
-    expect(feed.items.first.dc.modified, DateTime.utc(2000, 1, 2, 14));
-    expect(feed.items.first.dc.type, 'type');
-    expect(feed.items.first.dc.format, 'format');
-    expect(feed.items.first.dc.identifier, 'identifier');
-    expect(feed.items.first.dc.source, 'source');
-    expect(feed.items.first.dc.language, 'language');
-    expect(feed.items.first.dc.relation, 'relation');
-    expect(feed.items.first.dc.coverage, 'coverage');
-    expect(feed.items.first.dc.rights, 'rights');
+    expect(feed.items!.first.dc!.title, 'title');
+    expect(feed.items!.first.dc!.creator, 'creator');
+    expect(feed.items!.first.dc!.subject, 'subject');
+    expect(feed.items!.first.dc!.description, 'description');
+    expect(feed.items!.first.dc!.publisher, 'publisher');
+    expect(feed.items!.first.dc!.contributor, 'contributor');
+    expect(feed.items!.first.dc!.date, DateTime.utc(2000, 1, 2, 12));
+    expect(feed.items!.first.dc!.created, DateTime.utc(2000, 1, 2, 13));
+    expect(feed.items!.first.dc!.modified, DateTime.utc(2000, 1, 2, 14));
+    expect(feed.items!.first.dc!.type, 'type');
+    expect(feed.items!.first.dc!.format, 'format');
+    expect(feed.items!.first.dc!.identifier, 'identifier');
+    expect(feed.items!.first.dc!.source, 'source');
+    expect(feed.items!.first.dc!.language, 'language');
+    expect(feed.items!.first.dc!.relation, 'relation');
+    expect(feed.items!.first.dc!.coverage, 'coverage');
+    expect(feed.items!.first.dc!.rights, 'rights');
   });
 
   test('parse RSS-Empty.xml', () {
@@ -294,26 +294,26 @@ void main() {
 
     expect(feed.cloud, null);
 
-    expect(feed.categories.length, 0);
+    expect(feed.categories!.length, 0);
 
-    expect(feed.skipDays.length, 0);
+    expect(feed.skipDays!.length, 0);
 
-    expect(feed.skipHours.length, 0);
+    expect(feed.skipHours!.length, 0);
 
-    expect(feed.items.length, 1);
+    expect(feed.items!.length, 1);
 
-    expect(feed.items.first.title, null);
-    expect(feed.items.first.description, null);
-    expect(feed.items.first.link, null);
-    expect(feed.items.first.guid, null);
-    expect(feed.items.first.pubDate, null);
-    expect(feed.items.first.categories.length, 0);
-    expect(feed.items.first.author, null);
-    expect(feed.items.first.source, null);
-    expect(feed.items.first.comments, null);
-    expect(feed.items.first.enclosure, null);
+    expect(feed.items!.first.title, null);
+    expect(feed.items!.first.description, null);
+    expect(feed.items!.first.link, null);
+    expect(feed.items!.first.guid, null);
+    expect(feed.items!.first.pubDate, null);
+    expect(feed.items!.first.categories!.length, 0);
+    expect(feed.items!.first.author, null);
+    expect(feed.items!.first.source, null);
+    expect(feed.items!.first.comments, null);
+    expect(feed.items!.first.enclosure, null);
 
-    expect(feed.items.first.content, null);
+    expect(feed.items!.first.content, null);
   });
 
   test('parse RSS-Itunes.xml', () {
@@ -321,23 +321,23 @@ void main() {
 
     var feed = RssFeed.parse(xmlString);
 
-    expect(feed.itunes.author, 'Changelog Media');
-    expect(feed.itunes.summary, 'Foo');
-    expect(feed.itunes.explicit, false);
-    expect(feed.itunes.image.href,
+    expect(feed.itunes!.author, 'Changelog Media');
+    expect(feed.itunes!.summary, 'Foo');
+    expect(feed.itunes!.explicit, false);
+    expect(feed.itunes!.image!.href,
         'https://cdn.changelog.com/uploads/covers/go-time-original.png?v=63725770357');
-    expect(feed.itunes.keywords,
+    expect(feed.itunes!.keywords,
         'go,golang,open source,software,development'.split(','));
-    expect(feed.itunes.owner.name, 'Changelog Media');
-    expect(feed.itunes.owner.email, 'editors@changelog.com');
+    expect(feed.itunes!.owner!.name, 'Changelog Media');
+    expect(feed.itunes!.owner!.email, 'editors@changelog.com');
     expect(
         Set.from([
-          feed.itunes.categories[0].category,
-          feed.itunes.categories[1].category
+          feed.itunes!.categories![0]!.category,
+          feed.itunes!.categories![1]!.category
         ]),
         ['Technology', 'Foo']);
-    for (var category in feed.itunes.categories) {
-      switch (category.category) {
+    for (var category in feed.itunes!.categories!) {
+      switch (category!.category) {
         case 'Foo':
           expect(category.subCategories, ['Bar', 'Baz']);
           break;
@@ -346,29 +346,29 @@ void main() {
           break;
       }
     }
-    expect(feed.itunes.title, 'Go Time');
-    expect(feed.itunes.type, ItunesType.serial);
-    expect(feed.itunes.newFeedUrl, 'wubawuba');
-    expect(feed.itunes.block, true);
-    expect(feed.itunes.complete, true);
+    expect(feed.itunes!.title, 'Go Time');
+    expect(feed.itunes!.type, ItunesType.serial);
+    expect(feed.itunes!.newFeedUrl, 'wubawuba');
+    expect(feed.itunes!.block, true);
+    expect(feed.itunes!.complete, true);
 
-    var item = feed.items[0];
-    expect(item.itunes.episodeType, ItunesEpisodeType.full);
-    expect(item.itunes.episode, 1);
-    expect(item.itunes.season, 1);
-    expect(item.itunes.image.href,
+    var item = feed.items![0];
+    expect(item.itunes!.episodeType, ItunesEpisodeType.full);
+    expect(item.itunes!.episode, 1);
+    expect(item.itunes!.season, 1);
+    expect(item.itunes!.image!.href,
         'https://cdn.changelog.com/uploads/covers/go-time-original.png?v=63725770357');
-    expect(item.itunes.duration, Duration(minutes: 32, seconds: 30));
-    expect(item.itunes.explicit, false);
-    expect(item.itunes.keywords,
+    expect(item.itunes!.duration, Duration(minutes: 32, seconds: 30));
+    expect(item.itunes!.explicit, false);
+    expect(item.itunes!.keywords,
         'go,golang,open source,software,development'.split(','));
-    expect(item.itunes.subtitle, 'with Erik, Carlisia, and Brian');
-    expect(item.itunes.summary, 'Foo');
-    expect(item.itunes.author,
+    expect(item.itunes!.subtitle, 'with Erik, Carlisia, and Brian');
+    expect(item.itunes!.summary, 'Foo');
+    expect(item.itunes!.author,
         'Erik St. Martin, Carlisia Pinto, and Brian Ketelsen');
-    expect(item.itunes.explicit, false);
-    expect(item.itunes.title, 'awesome title');
-    expect(item.itunes.block, false);
+    expect(item.itunes!.explicit, false);
+    expect(item.itunes!.title, 'awesome title');
+    expect(item.itunes!.block, false);
   });
 
   test('parse RSS-RDF.xml', () {
@@ -379,12 +379,12 @@ void main() {
     expect(feed.title, 'Mozilla Dot Org');
     expect(feed.link, 'http://www.mozilla.org');
     expect(feed.description, 'the Mozilla Organization web site');
-    expect(feed.image.title, 'Mozilla');
-    expect(feed.image.url, 'http://www.mozilla.org/images/moz.gif');
-    expect(feed.image.link, 'http://www.mozilla.org');
-    expect(feed.items.length, 5);
-    expect(feed.items.first.title, 'New Status Updates');
-    expect(feed.items.first.link, 'http://www.mozilla.org/status/');
+    expect(feed.image!.title, 'Mozilla');
+    expect(feed.image!.url, 'http://www.mozilla.org/images/moz.gif');
+    expect(feed.image!.link, 'http://www.mozilla.org');
+    expect(feed.items!.length, 5);
+    expect(feed.items!.first.title, 'New Status Updates');
+    expect(feed.items!.first.link, 'http://www.mozilla.org/status/');
   });
 
   test('parse RSS-Syndication.xml', () {
@@ -395,17 +395,17 @@ void main() {
     expect(feed.title, 'Meerkat');
     expect(feed.link, 'http://meerkat.oreillynet.com');
     expect(feed.description, 'Meerkat: An Open Wire Service');
-    expect(feed.image.title, 'Meerkat Powered!');
-    expect(feed.image.url,
+    expect(feed.image!.title, 'Meerkat Powered!');
+    expect(feed.image!.url,
         'http://meerkat.oreillynet.com/icons/meerkat-powered.jpg');
-    expect(feed.image.link, 'http://meerkat.oreillynet.com');
-    expect(feed.syndication.updatePeriod, SyndicationUpdatePeriod.hourly);
-    expect(feed.syndication.updateFrequency, 2);
-    expect(feed.syndication.updateBase, DateTime.utc(2001, 1, 1, 12, 1));
-    expect(feed.items.length, 1);
-    expect(feed.items.first.title, 'XML: A Disruptive Technology');
-    expect(feed.items.first.description,
+    expect(feed.image!.link, 'http://meerkat.oreillynet.com');
+    expect(feed.syndication!.updatePeriod, SyndicationUpdatePeriod.hourly);
+    expect(feed.syndication!.updateFrequency, 2);
+    expect(feed.syndication!.updateBase, DateTime.utc(2001, 1, 1, 12, 1));
+    expect(feed.items!.length, 1);
+    expect(feed.items!.first.title, 'XML: A Disruptive Technology');
+    expect(feed.items!.first.description,
         'XML is placing increasingly heavy loads on the existing technical infrastructure of the Internet.');
-    expect(feed.items.first.link, 'http://c.moreover.com/click/here.pl?r123');
+    expect(feed.items!.first.link, 'http://c.moreover.com/click/here.pl?r123');
   });
 }


### PR DESCRIPTION
I migrated all the files to their null safe versions by running dart migrate and removing some of the bugs that came up. Here are the changes that I made:

1. Some factory constructors had to be converted to static methods. This is because null safety Dart 2.0 allows static methods to return null but not factory methods.
2. Updated pubspec dependencies to null safe variants.
3. Made most fields nullable and maintained the null checks that were present before. Especially in factory constructors. I did not want to start changing the logic for where the return values were used.

Closes #49 