### PR TITLE
Feature/access custom namespaces

### DIFF
--- a/lib/domain/custom_namespace/custom.dart
+++ b/lib/domain/custom_namespace/custom.dart
@@ -1,0 +1,26 @@
+import 'package:xml/xml.dart';
+
+class CustomNamespace {
+  final Map<String, dynamic> customTags;
+
+  CustomNamespace({ required this.customTags });
+
+  String? valueForKey(String key) {
+    return customTags[key];
+  }
+
+  factory CustomNamespace.parse(XmlElement element) {
+    final customTags = <String, dynamic>{};
+
+    element.descendantElements.forEach((descendantElement) {
+      customTags.addEntries([
+        MapEntry(
+          descendantElement.name.toString(),
+          descendantElement.text,
+        ),
+      ]);
+    });
+
+    return CustomNamespace(customTags: customTags);
+  }
+}

--- a/lib/domain/rss_item.dart
+++ b/lib/domain/rss_item.dart
@@ -1,3 +1,4 @@
+import 'package:webfeed/domain/custom_namespace/custom.dart';
 import 'package:webfeed/domain/dublin_core/dublin_core.dart';
 import 'package:webfeed/domain/itunes/itunes.dart';
 import 'package:webfeed/domain/media/media.dart';
@@ -25,6 +26,7 @@ class RssItem {
   final RssEnclosure? enclosure;
   final DublinCore? dc;
   final Itunes? itunes;
+  final CustomNamespace? customNamespace;
 
   RssItem({
     this.title,
@@ -41,6 +43,7 @@ class RssItem {
     this.enclosure,
     this.dc,
     this.itunes,
+    this.customNamespace,
   });
 
   factory RssItem.parse(XmlElement element) {
@@ -71,6 +74,7 @@ class RssItem {
           .firstOrNull,
       dc: DublinCore.parse(element),
       itunes: Itunes.parse(element),
+      customNamespace: CustomNamespace.parse(element),
     );
   }
 }

--- a/test/custom_namespace_test.dart
+++ b/test/custom_namespace_test.dart
@@ -1,0 +1,49 @@
+import 'dart:core';
+import 'dart:io';
+
+import 'package:test/test.dart';
+// import 'package:webfeed/domain/itunes/itunes_episode_type.dart';
+// import 'package:webfeed/domain/itunes/itunes_type.dart';
+// import 'package:webfeed/domain/syndication/syndication.dart';
+import 'package:webfeed/webfeed.dart';
+
+void main() {
+  test('Loads tags into customNamespace map.xml', () {
+    final expectValues = <Map<String, String>>[
+      {
+        'g-core:price': '26500.0',
+        'geo:lat': '50.43701',
+        'geo:long': '-104.62499',
+      },
+      {
+        'g-core:price': '7495.0',
+        'geo:lat': '50.4631',
+        'geo:long': '-104.59493',
+      },
+      {
+        'g-core:price': '7998.0',
+        'geo:lat': '50.48064',
+        'geo:long': '-104.61908',
+      },  
+      {
+        'g-core:price': '22495.0',
+        'geo:lat': '50.46893',
+        'geo:long': '-104.61199',
+      }
+    ];
+
+    final feed = RssFeed.parse(File('test/xml/Custom.xml').readAsStringSync());
+
+    expect(feed.title, 'Latest Kijiji ads. Location: Regina. Category: Cars & Trucks');
+    expect(feed.items!.length, 4);
+
+    var mapIndex = 0;
+    for (var item in feed.items!) {
+      expect(item.customNamespace!.valueForKey('g-core:price'), expectValues[mapIndex]['g-core:price']);
+      expect(item.customNamespace!.valueForKey('geo:lat'), expectValues[mapIndex]['geo:lat']);
+      expect(item.customNamespace!.valueForKey('geo:long'), expectValues[mapIndex]['geo:long']);
+
+      mapIndex++;
+    }
+  });
+}

--- a/test/xml/Custom.xml
+++ b/test/xml/Custom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:g-core="http://base.google.com/ns/1.0" xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#" version="2.0">
+  <channel>
+    <title>Latest Kijiji ads. Location: Regina. Category: Cars &amp; Trucks</title>
+    <link>https://www.kijiji.ca/b-cars-trucks/regina/fiat-new__used/c174l1700196a54a49</link>
+    <description>Latest Kijiji ads. Location: Regina. Category: Cars &amp; Trucks</description>
+    <language>en-ca</language>
+    <copyright>(c) Kijiji Canada 2022</copyright>
+    <pubDate>Wed, 10 Aug 2022 17:02:30 GMT</pubDate>
+    <dc:date>2022-08-10T17:02:30Z</dc:date>
+    <dc:language>en-ca</dc:language>
+    <dc:rights>(c) Kijiji Canada 2022</dc:rights>
+    <atom:link href="https://www.kijiji.ca/rss-srp-cars-trucks/regina/fiat-new__used/c174l1700196a54a49" type="application/rss+xml" rel="self" />
+    <image>
+      <title>Latest Kijiji ads. Location: Regina. Category: Cars &amp; Trucks</title>
+      <url>https://ca.classistatic.com/static/V/11112/img/icon/logo.gif</url>
+      <link>https://www.kijiji.ca/b-cars-trucks/regina/fiat-new__used/c174l1700196a54a49</link>
+    </image>
+    <item>
+      <title>Fiat 500 Abarth</title>
+      <link>https://www.kijiji.ca/v-cars-trucks/regina/fiat-500-abarth/1626712297</link>
+      <description>Fiat 500 Abarth turbocharged four-cylinder -This coupe Abarth is a special car with a ton of charisma. One owner - very little mileage and kept in a garage - comes with a set of winter tires. The ...</description>
+      <enclosure url="https://media.kijiji.ca/api/v1/ca-prod-fsbo-ads/images/bb/bb543f45-3696-48ab-b426-e69057f9756a?rule=kijijica-960-webp" length="14" type="image/jpeg" />
+      <pubDate>Wed, 10 Aug 2022 03:07:53 GMT</pubDate>
+      <guid>https://www.kijiji.ca/v-cars-trucks/regina/fiat-500-abarth/1626712297</guid>
+      <dc:date>2022-08-10T03:07:53Z</dc:date>
+      <geo:lat>50.43701</geo:lat>
+      <geo:long>-104.62499</geo:long>
+      <g-core:price>26500.0</g-core:price>
+    </item>
+    <item>
+      <title>2012  FIAT 500 SPORT HB / 5 SPD MANUAL TRANS / VERY CHEAP ON GAS</title>
+      <link>https://www.kijiji.ca/v-cars-trucks/regina/2012-fiat-500-sport-hb-5-spd-manual-trans-very-cheap-on-gas/m4014879</link>
+      <description>2012 FIAT 500 SPORT HB / 5 SPEED MANUAL TRANSMISSION / VERY CHEAP ON GAS NEW TYRES / CUTE LITTLE CAR / LEATHER SEATS / FRESH OIL CHANGE / FRESH DETAIL MUST SEE We make every effort to present ...</description>
+      <enclosure url="https://media.kijiji.ca/api/v1/autos-prod-ads/images/04/04f97598-2fb3-482d-a5ce-261bf2064ea6?rule=kijijica-960-webp" length="14" type="image/jpeg" />
+      <pubDate>Tue, 09 Aug 2022 00:25:25 GMT</pubDate>
+      <guid>https://www.kijiji.ca/v-cars-trucks/regina/2012-fiat-500-sport-hb-5-spd-manual-trans-very-cheap-on-gas/m4014879</guid>
+      <dc:date>2022-08-09T00:25:25Z</dc:date>
+      <geo:lat>50.4631</geo:lat>
+      <geo:long>-104.59493</geo:long>
+      <g-core:price>7495.0</g-core:price>
+    </item>
+    <item>
+      <title>2012 Fiat 500 Pop</title>
+      <link>https://www.kijiji.ca/v-cars-trucks/regina/2012-fiat-500-pop/m4324207</link>
+      <description>Engine: 4 Cylinder Engine 1.4L L/100Km City: 7.4 L/100Km Hwy: 5.7 Safety Equipment Electronic stability control Driver &amp;amp; front passenger advanced multi-stage frontal airbags Supplemental front seat ...</description>
+      <enclosure url="https://media.kijiji.ca/api/v1/autos-prod-ads/images/b9/b9610ddb-6246-47d0-a35e-aae00be33324?rule=kijijica-960-webp" length="14" type="image/jpeg" />
+      <pubDate>Mon, 08 Aug 2022 15:24:04 GMT</pubDate>
+      <guid>https://www.kijiji.ca/v-cars-trucks/regina/2012-fiat-500-pop/m4324207</guid>
+      <dc:date>2022-08-08T15:24:04Z</dc:date>
+      <geo:lat>50.48064</geo:lat>
+      <geo:long>-104.61908</geo:long>
+      <g-core:price>7998.0</g-core:price>
+    </item>
+    <item>
+      <title>2017 Fiat 500X LOW KM | LOCAL TRADE | AWD!</title>
+      <link>https://www.kijiji.ca/v-cars-trucks/regina/2017-fiat-500x-low-km-local-trade-awd/m4412340</link>
+      <description>See Dealer Website for Details. Safety Equipment Electronic Stability Control (ESC) And Roll Stability Control (RSC) ABS And Driveline Traction Control Side Impact Beams Dual Stage Driver And ...</description>
+      <enclosure url="https://media.kijiji.ca/api/v1/autos-prod-ads/images/2f/2ff27bc9-fd7a-43fe-b422-4baf7b07d8d6?rule=kijijica-960-webp" length="14" type="image/jpeg" />
+      <pubDate>Fri, 29 Jul 2022 10:27:16 GMT</pubDate>
+      <guid>https://www.kijiji.ca/v-cars-trucks/regina/2017-fiat-500x-low-km-local-trade-awd/m4412340</guid>
+      <dc:date>2022-07-29T10:27:16Z</dc:date>
+      <geo:lat>50.46893</geo:lat>
+      <geo:long>-104.61199</geo:long>
+      <g-core:price>22495.0</g-core:price>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
I've noticed a bit of a trend -- new namespaces are introduced continually. And, this can continue.

But for now, I need support for:

* namespaces not yet introduced (I'm parsing out g-core items... no idea what that is)
* namespaces used incorrectly (my example code declares itself as an Atom feed, but does not follow the spec. I had to load it in as an RSS feed instead

This request adds support for reading in the raw text of unidentified tags (well... ALL tags at the moment. I'd love feedback regarding what to exclude).

This allows me to access:

```
...
<item>
  <g-core:price>2499.99</g-core:price>
</item>
```

via

`feed.items!.first.customNamespace!.valueForKey('g-core:price')`