### PR TITLE
Feature/extended media group

### DIFF
--- a/lib/domain/media/group.dart
+++ b/lib/domain/media/group.dart
@@ -2,6 +2,7 @@ import 'package:webfeed/domain/media/category.dart';
 import 'package:webfeed/domain/media/content.dart';
 import 'package:webfeed/domain/media/credit.dart';
 import 'package:webfeed/domain/media/rating.dart';
+import 'package:webfeed/domain/media/thumbnail.dart';
 import 'package:webfeed/util/iterable.dart';
 import 'package:xml/xml.dart';
 
@@ -10,12 +11,14 @@ class Group {
   final List<Credit>? credits;
   final Category? category;
   final Rating? rating;
+  final Thumbnail? thumbnail;
 
   Group({
     this.contents,
     this.credits,
     this.category,
     this.rating,
+    this.thumbnail,
   });
 
   factory Group.parse(XmlElement element) {
@@ -35,6 +38,10 @@ class Group {
       rating: element
           .findElements('media:rating')
           .map((e) => Rating.parse(e))
+          .firstOrNull,
+      thumbnail: element
+          .findElements('media:thumbnail')
+          .map((e) => Thumbnail.parse(e))
           .firstOrNull,
     );
   }

--- a/lib/domain/media/group.dart
+++ b/lib/domain/media/group.dart
@@ -1,8 +1,10 @@
 import 'package:webfeed/domain/media/category.dart';
 import 'package:webfeed/domain/media/content.dart';
 import 'package:webfeed/domain/media/credit.dart';
+import 'package:webfeed/domain/media/description.dart';
 import 'package:webfeed/domain/media/rating.dart';
 import 'package:webfeed/domain/media/thumbnail.dart';
+import 'package:webfeed/domain/media/title.dart';
 import 'package:webfeed/util/iterable.dart';
 import 'package:xml/xml.dart';
 
@@ -12,6 +14,8 @@ class Group {
   final Category? category;
   final Rating? rating;
   final Thumbnail? thumbnail;
+  final Title? title;
+  final Description? description;
 
   Group({
     this.contents,
@@ -19,6 +23,8 @@ class Group {
     this.category,
     this.rating,
     this.thumbnail,
+    this.title,
+    this.description,
   });
 
   factory Group.parse(XmlElement element) {
@@ -42,6 +48,14 @@ class Group {
       thumbnail: element
           .findElements('media:thumbnail')
           .map((e) => Thumbnail.parse(e))
+          .firstOrNull,
+      title: element
+          .findElements('media:title')
+          .map((e) => Title.parse(e))
+          .firstOrNull,
+      description: element
+          .findElements('media:title')
+          .map((e) => Description.parse(e))
           .firstOrNull,
     );
   }

--- a/test/atom_test.dart
+++ b/test/atom_test.dart
@@ -257,4 +257,31 @@ void main() {
     expect(item.content, null);
     expect(item.rights, null);
   });
+
+
+  test('parse Atom-YouTube.xml media group', () {
+    var xmlString = File('test/xml/Atom-YouTube.xml').readAsStringSync();
+
+    var feed = AtomFeed.parse(xmlString);
+
+    expect(feed.items!.length, 1);
+    var item = feed.items!.first;
+
+    var mediaGroup = item.media?.group;
+    expect(mediaGroup, isNotNull);
+
+    var thumbnail = mediaGroup?.thumbnail;
+    expect(thumbnail, isNotNull);
+    expect(thumbnail?.url, 'https://i4.ytimg.com/vi/SD6exDEZe3A/hqdefault.jpg');
+
+    var title = mediaGroup?.title;
+    expect(title, isNotNull);
+    expect(title?.value, 'Saifedean Ammous: How Bitcoin ENDS Inflation');
+
+    var description = mediaGroup?.description;
+    expect(description, isNotNull);
+    expect(description?.value, isNotNull);
+
+  });
+
 }

--- a/test/xml/Atom-YouTube.xml
+++ b/test/xml/Atom-YouTube.xml
@@ -1,0 +1,35 @@
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
+	<link rel="self" href="http://www.youtube.com/feeds/videos.xml?channel_id=UCl4takhOQtiyprismCPsa2Q"/>
+	<id>yt:channel:</id>
+	<yt:channelId/>
+	<title>Swan Bitcoin</title>
+	<link rel="alternate" href="https://www.youtube.com/channel/UCl4takhOQtiyprismCPsa2Q"/>
+	<author>
+	<name>Swan Bitcoin</name>
+	<uri>https://www.youtube.com/channel/UCl4takhOQtiyprismCPsa2Q</uri>
+	</author>
+	<published>2020-04-26T16:35:43+00:00</published>
+	<entry>
+		<id>yt:video:SD6exDEZe3A</id>
+		<yt:videoId>SD6exDEZe3A</yt:videoId>
+		<yt:channelId>UCl4takhOQtiyprismCPsa2Q</yt:channelId>
+		<title>Saifedean Ammous: How Bitcoin ENDS Inflation</title>
+		<link rel="alternate" href="https://www.youtube.com/watch?v=SD6exDEZe3A"/>
+		<author>
+		<name>Swan Bitcoin</name>
+		<uri>https://www.youtube.com/channel/UCl4takhOQtiyprismCPsa2Q</uri>
+		</author>
+		<published>2023-04-29T16:21:00+00:00</published>
+		<updated>2023-04-29T16:21:00+00:00</updated>
+		<media:group>
+			<media:title>Saifedean Ammous: How Bitcoin ENDS Inflation</media:title>
+			<media:content url="https://www.youtube.com/v/SD6exDEZe3A?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+			<media:thumbnail url="https://i4.ytimg.com/vi/SD6exDEZe3A/hqdefault.jpg" width="480" height="360"/>
+			<media:description>Connect with Swan on social media: Twitter: https://twitter.com/SwanBitcoin​​​Instagram: https://instagram.com/SwanBitcoin Telegram: https://t.me/swansignal​​​LinkedIn: https://www.linkedin.com/company/swanbitcoin Swan Bitcoin is the best way to accumulate Bitcoin with automatic recurring buys and instant buys from $10 to $10 million. Get started in just 5 minutes. Your first $10 purchase is on us: https://swanbitcoin.com/yt Download the all new Swan app! iOS: https://apps.apple.com/us/app/swan-bitcoin/id1576287352 Android: https://play.google.com/store/apps/details?id=com.swanbitcoin.android&pli=1 Join us for Pacific Bitcoin Festival 2023! Purchase your tickets now before prices go up: https://www.pacificbitcoin.com/?utm_medium=social&utm_source=youtube&utm_campaign=youtube_description Are you a high net worth individual or do you represent corporation that might be interested in learning more about Bitcoin? Swan Private guides corporations and high net worth individuals toward building generational wealth with Bitcoin. Find out more at: https://www.swanbitcoin.com/private/?utm_medium=social&utm_source=youtube&utm_campaign=youtube_post Check out the best place for Bitcoin education, Swan Bitcoin’s “Bitcoin Canon”. Compiling all of the greatest articles, news sources, videos and more from your favorite bitcoiners! https://swanbitcoin.com/cannon?utm_medium=social&utm_source=youtube&utm_campaign=youtube_description Get paid to recruit new Bitcoiners: https://swanbitcoin.com/enlist?utm_medium=social&utm_source=twitter&utm_campaign=social_selling #Bitcoin #SwanBitcoin</media:description>
+			<media:community>
+				<media:starRating count="117" average="5.00" min="1" max="5"/>
+				<media:statistics views="1078"/>
+			</media:community>
+		</media:group>
+	</entry>
+</feed>


### PR DESCRIPTION
Some Atom feeds, like the ones on YouTube, have the `thumbnail` image defined inside the `media:group` element, like below:

```
...
		<media:group>
			<media:title>Saifedean Ammous: How Bitcoin ENDS Inflation</media:title>
			<media:content url="https://www.youtube.com/v/SD6exDEZe3A?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
			<media:thumbnail url="https://i4.ytimg.com/vi/SD6exDEZe3A/hqdefault.jpg" width="480" height="360"/>
			<media:description>Removed for brevity</media:description>
			<media:community>
				<media:starRating count="117" average="5.00" min="1" max="5"/>
				<media:statistics views="1078"/>
			</media:community>
		</media:group>
...
```

Because of this peculiarity, it's currently impossible for a `webfeed` user to get the thumbnail of a YouTube video. 

This PR adds the following properties to the Group class:
```
  final Thumbnail? thumbnail;
  final Title? title;
  final Description? description;
```

The user can now call
```
item.media?.group?.thumbnail?.url
```
to get a YouTube thumbnail URL.

